### PR TITLE
Add pytest migration rules for unittest-to-pytest conversion

### DIFF
--- a/refactor/rules/pytest_migration.py
+++ b/refactor/rules/pytest_migration.py
@@ -1,0 +1,605 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.actions import Erase
+from refactor.common import clone
+from refactor.core import Rule
+
+# Names that indicate a unittest base class
+_UNITTEST_BASES = frozenset({"TestCase", "IsolatedAsyncioWrapperTestCase"})
+
+# Qualified names: unittest.TestCase, unittest.IsolatedAsyncioTestCase, etc.
+_UNITTEST_MODULE = "unittest"
+
+# The specific wrapper import module path
+_WRAPPER_MODULE = "test.isolated_asyncio_wrapper_test_case"
+_WRAPPER_CLASS = "IsolatedAsyncioWrapperTestCase"
+
+
+def _is_unittest_base(node: ast.expr, unittest_names: set[str]) -> bool:
+    """Return True if the expression is a known unittest base class reference."""
+    if isinstance(node, ast.Attribute):
+        # unittest.TestCase style
+        return (
+            isinstance(node.value, ast.Name)
+            and node.value.id == _UNITTEST_MODULE
+        )
+    if isinstance(node, ast.Name):
+        return node.id in unittest_names
+    return False
+
+
+def _get_unittest_names_from_imports(tree: ast.Module) -> set[str]:
+    """Collect names imported from unittest (e.g. TestCase from 'from unittest import TestCase')."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == _UNITTEST_MODULE:
+                for alias in node.names:
+                    imported_name = alias.asname or alias.name
+                    names.add(imported_name)
+            elif node.module == _WRAPPER_MODULE:
+                for alias in node.names:
+                    if alias.name == _WRAPPER_CLASS:
+                        imported_name = alias.asname or alias.name
+                        names.add(imported_name)
+    return names
+
+
+class RemoveUnittestInheritance(Rule):
+    """Remove unittest base classes from test class definitions.
+
+    Handles:
+    - class Foo(unittest.TestCase): -> class Foo:
+    - class Foo(TestCase): -> class Foo:  (when TestCase imported from unittest)
+    - class Foo(IsolatedAsyncioWrapperTestCase): -> class Foo:
+    - class Foo(Mixin, TestCase): -> class Foo(Mixin):
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ClassDef)
+        assert len(node.bases) > 0
+
+        # Collect names that represent unittest base classes in this module
+        tree = self.context.tree
+        assert isinstance(tree, ast.Module)
+        unittest_names = _get_unittest_names_from_imports(tree)
+
+        # Check if any base is a unittest base
+        has_unittest_base = any(
+            _is_unittest_base(base, unittest_names) for base in node.bases
+        )
+        assert has_unittest_base
+
+        # Filter out unittest bases, keeping non-unittest ones
+        new_bases = [
+            base for base in node.bases
+            if not _is_unittest_base(base, unittest_names)
+        ]
+
+        # Only transform if something actually changed
+        assert len(new_bases) != len(node.bases)
+
+        new_node = clone(node)
+        new_node.bases = new_bases
+        return Replace(node, new_node)
+
+
+def _unittest_is_still_used(tree: ast.Module) -> bool:
+    """Return True if 'unittest' is used as a name in expressions (e.g. unittest.mock)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            if isinstance(node.value, ast.Name) and node.value.id == _UNITTEST_MODULE:
+                return True
+        if isinstance(node, ast.Name):
+            if node.id == _UNITTEST_MODULE:
+                return True
+    return False
+
+
+def _classdef_still_uses_name(tree: ast.Module, name: str) -> bool:
+    """Return True if any ClassDef base still references the given name."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            for base in node.bases:
+                if isinstance(base, ast.Name) and base.id == name:
+                    return True
+    return False
+
+
+class RemoveUnittestImport(Rule):
+    """Remove 'import unittest' or 'from unittest import TestCase' when no longer needed.
+
+    - Removes 'import unittest' if unittest is not used anywhere else in the module.
+    - Removes 'from unittest import TestCase' if TestCase is not used as a class base.
+    """
+
+    def match(self, node: ast.AST) -> Erase | None:
+        assert isinstance(node, (ast.Import, ast.ImportFrom))
+
+        tree = self.context.tree
+        assert isinstance(tree, ast.Module)
+
+        if isinstance(node, ast.Import):
+            # Handle 'import unittest'
+            assert any(alias.name == _UNITTEST_MODULE for alias in node.names)
+
+            # Check if unittest is still referenced anywhere (excluding this import)
+            used = _unittest_is_still_used_excluding_import(tree, node)
+            assert not used
+            return Erase(node)
+
+        if isinstance(node, ast.ImportFrom):
+            # Handle 'from unittest import TestCase [, ...]'
+            assert node.module == _UNITTEST_MODULE
+
+            # Find which names from this import are no longer used as class bases
+            unused_names = []
+            for alias in node.names:
+                imported_name = alias.asname or alias.name
+                if not _classdef_still_uses_name(tree, imported_name):
+                    unused_names.append(alias)
+
+            # Only act if ALL names in this import are unused
+            assert len(unused_names) == len(node.names)
+            return Erase(node)
+
+        return None
+
+
+def _unittest_is_still_used_excluding_import(
+    tree: ast.Module, import_node: ast.Import
+) -> bool:
+    """Return True if 'unittest' is used in any node other than the given import."""
+    for node in ast.walk(tree):
+        if node is import_node:
+            continue
+        if isinstance(node, ast.Attribute):
+            if isinstance(node.value, ast.Name) and node.value.id == _UNITTEST_MODULE:
+                return True
+        if isinstance(node, ast.Name):
+            if node.id == _UNITTEST_MODULE:
+                return True
+    return False
+
+
+class RemoveTestWrapperImport(Rule):
+    """Remove 'from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase'
+    when the class is no longer used as a base class.
+    """
+
+    def match(self, node: ast.AST) -> Erase | None:
+        assert isinstance(node, ast.ImportFrom)
+        assert node.module == _WRAPPER_MODULE
+
+        # Check that this import includes IsolatedAsyncioWrapperTestCase
+        wrapper_aliases = [
+            alias for alias in node.names if alias.name == _WRAPPER_CLASS
+        ]
+        assert len(wrapper_aliases) > 0
+
+        tree = self.context.tree
+        assert isinstance(tree, ast.Module)
+
+        # Check if any of the imported names are still used
+        for alias in wrapper_aliases:
+            imported_name = alias.asname or alias.name
+            if _classdef_still_uses_name(tree, imported_name):
+                return None
+
+        return Erase(node)
+
+
+def _make_name(id: str) -> ast.Name:
+    """Create an ast.Name node with Load context."""
+    return ast.Name(id=id, ctx=ast.Load())
+
+
+def _make_attr_call(obj: str, attr: str, args: list[ast.expr]) -> ast.Call:
+    """Create ast.Call for obj.attr(args...)."""
+    return ast.Call(
+        func=ast.Attribute(
+            value=_make_name(obj),
+            attr=attr,
+            ctx=ast.Load(),
+        ),
+        args=args,
+        keywords=[],
+    )
+
+
+def _extract_msg(call: ast.Call, msg_index: int) -> ast.expr | None:
+    """Extract optional message argument at msg_index or from 'msg' keyword."""
+    if len(call.args) > msg_index:
+        return call.args[msg_index]
+    for kw in call.keywords:
+        if kw.arg == "msg":
+            return kw.value
+    return None
+
+
+# Map from assertion method name to a callable that takes the Call node and
+# returns the test expression for ast.Assert.
+def _conv_equal(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.Eq()], comparators=[call.args[1]])
+
+def _conv_not_equal(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.NotEq()], comparators=[call.args[1]])
+
+def _conv_true(call: ast.Call) -> ast.expr:
+    return call.args[0]
+
+def _conv_false(call: ast.Call) -> ast.expr:
+    return ast.UnaryOp(op=ast.Not(), operand=call.args[0])
+
+def _conv_is(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.Is()], comparators=[call.args[1]])
+
+def _conv_is_not(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.IsNot()], comparators=[call.args[1]])
+
+def _conv_is_none(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.Is()], comparators=[ast.Constant(value=None)])
+
+def _conv_is_not_none(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.IsNot()], comparators=[ast.Constant(value=None)])
+
+def _conv_in(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.In()], comparators=[call.args[1]])
+
+def _conv_not_in(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.NotIn()], comparators=[call.args[1]])
+
+def _conv_is_instance(call: ast.Call) -> ast.expr:
+    return ast.Call(
+        func=_make_name("isinstance"),
+        args=[call.args[0], call.args[1]],
+        keywords=[],
+    )
+
+def _conv_almost_equal(call: ast.Call) -> ast.expr:
+    approx = _make_attr_call("pytest", "approx", [call.args[1]])
+    return ast.Compare(left=call.args[0], ops=[ast.Eq()], comparators=[approx])
+
+def _conv_greater(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.Gt()], comparators=[call.args[1]])
+
+def _conv_greater_equal(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.GtE()], comparators=[call.args[1]])
+
+def _conv_less(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.Lt()], comparators=[call.args[1]])
+
+def _conv_less_equal(call: ast.Call) -> ast.expr:
+    return ast.Compare(left=call.args[0], ops=[ast.LtE()], comparators=[call.args[1]])
+
+def _conv_regex(call: ast.Call) -> ast.expr:
+    # assertRegex(s, r) -> re.search(r, s)  — note argument order swap
+    return _make_attr_call("re", "search", [call.args[1], call.args[0]])
+
+def _conv_count_equal(call: ast.Call) -> ast.expr:
+    sorted_a = _make_attr_call("", "sorted", [call.args[0]])
+    sorted_a = ast.Call(func=_make_name("sorted"), args=[call.args[0]], keywords=[])
+    sorted_b = ast.Call(func=_make_name("sorted"), args=[call.args[1]], keywords=[])
+    return ast.Compare(left=sorted_a, ops=[ast.Eq()], comparators=[sorted_b])
+
+
+# Maps method name → (converter_fn, msg_arg_index)
+_ASSERT_CONVERTERS: dict[str, tuple[object, int]] = {
+    "assertEqual":        (_conv_equal,         2),
+    "assertNotEqual":     (_conv_not_equal,      2),
+    "assertTrue":         (_conv_true,           1),
+    "assertFalse":        (_conv_false,          1),
+    "assertIs":           (_conv_is,             2),
+    "assertIsNot":        (_conv_is_not,         2),
+    "assertIsNone":       (_conv_is_none,        1),
+    "assertIsNotNone":    (_conv_is_not_none,    1),
+    "assertIn":           (_conv_in,             2),
+    "assertNotIn":        (_conv_not_in,         2),
+    "assertIsInstance":   (_conv_is_instance,    2),
+    "assertAlmostEqual":  (_conv_almost_equal,   2),
+    "assertGreater":      (_conv_greater,        2),
+    "assertGreaterEqual": (_conv_greater_equal,  2),
+    "assertLess":         (_conv_less,           2),
+    "assertLessEqual":    (_conv_less_equal,     2),
+    "assertRegex":        (_conv_regex,          2),
+    "assertCountEqual":   (_conv_count_equal,    2),
+}
+
+
+class ConvertAssertions(Rule):
+    """Convert unittest self.assertX() calls to plain pytest assert statements.
+
+    Examples:
+        self.assertEqual(a, b)      -> assert a == b
+        self.assertTrue(x)          -> assert x
+        self.assertAlmostEqual(a,b) -> assert a == pytest.approx(b)
+        self.assertRegex(s, r)      -> assert re.search(r, s)
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.Expr)
+        assert isinstance(node.value, ast.Call)
+
+        call = node.value
+        assert isinstance(call.func, ast.Attribute)
+        assert isinstance(call.func.value, ast.Name)
+        assert call.func.value.id == "self"
+
+        method_name = call.func.attr
+        assert method_name in _ASSERT_CONVERTERS
+
+        converter_fn, msg_index = _ASSERT_CONVERTERS[method_name]
+
+        test_expr = converter_fn(call)  # type: ignore[operator]
+        msg_expr = _extract_msg(call, msg_index)
+
+        new_node = ast.Assert(test=test_expr, msg=msg_expr)
+        ast.copy_location(new_node, node)
+        ast.fix_missing_locations(new_node)
+
+        return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# ConvertSetUpTearDown
+# ---------------------------------------------------------------------------
+
+def _make_fixture_decorator(autouse: bool = True) -> ast.expr:
+    """Create @pytest.fixture(autouse=True) decorator node."""
+    return ast.Call(
+        func=ast.Attribute(
+            value=_make_name("pytest"),
+            attr="fixture",
+            ctx=ast.Load(),
+        ),
+        args=[],
+        keywords=[
+            ast.keyword(arg="autouse", value=ast.Constant(value=autouse))
+        ],
+    )
+
+
+class ConvertSetUpTearDown(Rule):
+    """Convert unittest setUp/tearDown methods to pytest fixtures.
+
+    - setUp(self) -> @pytest.fixture(autouse=True) / def setup(self)
+    - asyncSetUp(self) -> @pytest.fixture(autouse=True) / async def setup(self)
+    - tearDown(self) -> @pytest.fixture(autouse=True) / def teardown_fixture(self) with yield prepended
+    - asyncTearDown(self) -> @pytest.fixture(autouse=True) / async def teardown_fixture(self) with yield
+    - super().setUp() calls -> Erase
+    - self.maxDiff = None -> Erase
+    """
+
+    _SETUP_NAMES = frozenset({"setUp", "asyncSetUp"})
+    _TEARDOWN_NAMES = frozenset({"tearDown", "asyncTearDown"})
+
+    def match(self, node: ast.AST) -> Replace | Erase | None:
+        # --- Handle super().setUp() removal ---
+        if isinstance(node, ast.Expr):
+            assert isinstance(node.value, ast.Call)
+            call = node.value
+            assert isinstance(call.func, ast.Attribute)
+            assert call.func.attr in ("setUp", "asyncSetUp", "tearDown", "asyncTearDown")
+            assert isinstance(call.func.value, ast.Call)
+            inner = call.func.value
+            assert isinstance(inner.func, ast.Name)
+            assert inner.func.id == "super"
+            return Erase(node)
+
+        # --- Handle self.maxDiff = None removal ---
+        if isinstance(node, ast.Assign):
+            assert len(node.targets) == 1
+            target = node.targets[0]
+            assert isinstance(target, ast.Attribute)
+            assert isinstance(target.value, ast.Name)
+            assert target.value.id == "self"
+            assert target.attr == "maxDiff"
+            assert isinstance(node.value, ast.Constant)
+            assert node.value.value is None
+            return Erase(node)
+
+        # --- Handle setUp / asyncSetUp / tearDown / asyncTearDown ---
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        assert node.name in (self._SETUP_NAMES | self._TEARDOWN_NAMES)
+
+        new_node = clone(node)
+        fixture_dec = _make_fixture_decorator(autouse=True)
+        ast.fix_missing_locations(fixture_dec)
+
+        # Prepend the fixture decorator (keep existing decorators after it)
+        new_node.decorator_list = [fixture_dec] + new_node.decorator_list
+
+        if node.name in self._TEARDOWN_NAMES:
+            new_node.name = "teardown_fixture"
+            # Prepend a bare yield statement to the body
+            yield_stmt = ast.Expr(value=ast.Yield(value=None))
+            ast.fix_missing_locations(yield_stmt)
+            new_node.body = [yield_stmt] + new_node.body
+        else:
+            # setUp / asyncSetUp -> rename to setup
+            new_node.name = "setup"
+
+        ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# ConvertAssertRaises
+# ---------------------------------------------------------------------------
+
+class ConvertAssertRaises(Rule):
+    """Convert self.assertRaises(...) context managers to pytest.raises(...).
+
+    Example:
+        with self.assertRaises(ValueError):   ->   with pytest.raises(ValueError):
+            ...                                        ...
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.With)
+
+        # Find the first item whose context_expr is self.assertRaises(...)
+        new_items = list(node.items)
+        changed = False
+
+        for i, item in enumerate(new_items):
+            ctx = item.context_expr
+            assert isinstance(ctx, ast.Call)
+            assert isinstance(ctx.func, ast.Attribute)
+            assert isinstance(ctx.func.value, ast.Name)
+            assert ctx.func.value.id == "self"
+            assert ctx.func.attr == "assertRaises"
+
+            # Build pytest.raises(...) call with the same args/keywords
+            new_call = ast.Call(
+                func=ast.Attribute(
+                    value=_make_name("pytest"),
+                    attr="raises",
+                    ctx=ast.Load(),
+                ),
+                args=list(ctx.args),
+                keywords=list(ctx.keywords),
+            )
+            ast.copy_location(new_call, ctx)
+            ast.fix_missing_locations(new_call)
+
+            new_item = ast.withitem(
+                context_expr=new_call,
+                optional_vars=item.optional_vars,
+            )
+            new_items[i] = new_item
+            changed = True
+            break  # only transform the first matching item per With node
+
+        assert changed
+
+        new_node = clone(node)
+        new_node.items = new_items
+        ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# ConvertUnittestDecorators
+# ---------------------------------------------------------------------------
+
+def _build_pytest_mark_skip(args: list[ast.expr]) -> ast.expr:
+    """Build @pytest.mark.skip(reason=<reason>) from @unittest.skip(<reason>)."""
+    reason_arg = args[0] if args else ast.Constant(value="")
+    return ast.Call(
+        func=ast.Attribute(
+            value=ast.Attribute(
+                value=_make_name("pytest"),
+                attr="mark",
+                ctx=ast.Load(),
+            ),
+            attr="skip",
+            ctx=ast.Load(),
+        ),
+        args=[],
+        keywords=[ast.keyword(arg="reason", value=reason_arg)],
+    )
+
+
+def _build_pytest_mark_skipif(
+    condition: ast.expr, reason: ast.expr
+) -> ast.expr:
+    """Build @pytest.mark.skipif(condition, reason=<reason>)."""
+    return ast.Call(
+        func=ast.Attribute(
+            value=ast.Attribute(
+                value=_make_name("pytest"),
+                attr="mark",
+                ctx=ast.Load(),
+            ),
+            attr="skipif",
+            ctx=ast.Load(),
+        ),
+        args=[condition],
+        keywords=[ast.keyword(arg="reason", value=reason)],
+    )
+
+
+def _match_unittest_skip_decorator(
+    dec: ast.expr,
+) -> tuple[str, list[ast.expr]] | None:
+    """Return (decorator_attr_name, args) if dec is unittest.skip/skipIf/skipUnless."""
+    _SKIP_NAMES = ("skip", "skipIf", "skipUnless")
+
+    if isinstance(dec, ast.Call):
+        func = dec.func
+        if isinstance(func, ast.Attribute) and func.attr in _SKIP_NAMES:
+            if isinstance(func.value, ast.Name) and func.value.id == "unittest":
+                return func.attr, dec.args
+        # bare name (from unittest import skip)
+        if isinstance(func, ast.Name) and func.id in _SKIP_NAMES:
+            return func.id, dec.args
+
+    return None
+
+
+class ConvertUnittestDecorators(Rule):
+    """Convert unittest skip decorators to pytest equivalents.
+
+    - @unittest.skip("reason")        -> @pytest.mark.skip(reason="reason")
+    - @unittest.skipIf(cond, "r")     -> @pytest.mark.skipif(cond, reason="r")
+    - @unittest.skipUnless(cond, "r") -> @pytest.mark.skipif(not cond, reason="r")
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        assert len(node.decorator_list) > 0
+
+        new_decorators = list(node.decorator_list)
+        changed = False
+
+        for i, dec in enumerate(new_decorators):
+            result = _match_unittest_skip_decorator(dec)
+            if result is None:
+                continue
+
+            attr_name, args = result
+            if attr_name == "skip":
+                new_dec = _build_pytest_mark_skip(args)
+            elif attr_name == "skipIf":
+                # skipIf(condition, reason)
+                assert len(args) >= 2
+                new_dec = _build_pytest_mark_skipif(args[0], args[1])
+            elif attr_name == "skipUnless":
+                # skipUnless(condition, reason) -> skipif(not condition, reason)
+                assert len(args) >= 2
+                negated = ast.UnaryOp(op=ast.Not(), operand=args[0])
+                ast.fix_missing_locations(negated)
+                new_dec = _build_pytest_mark_skipif(negated, args[1])
+            else:
+                continue
+
+            ast.fix_missing_locations(new_dec)
+            new_decorators[i] = new_dec
+            changed = True
+
+        assert changed
+
+        new_node = clone(node)
+        new_node.decorator_list = new_decorators
+        ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)
+
+
+# All migration rules in application order
+ALL_RULES = [
+    RemoveUnittestInheritance,
+    RemoveUnittestImport,
+    RemoveTestWrapperImport,
+    ConvertAssertions,
+    ConvertSetUpTearDown,
+    ConvertAssertRaises,
+    ConvertUnittestDecorators,
+]
+
+if __name__ == "__main__":
+    import refactor
+    refactor.run(ALL_RULES)

--- a/tests/test_pytest_migration.py
+++ b/tests/test_pytest_migration.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.pytest_migration import (
+    ALL_RULES,
+    ConvertAssertions,
+    ConvertAssertRaises,
+    ConvertSetUpTearDown,
+    ConvertUnittestDecorators,
+    RemoveTestWrapperImport,
+    RemoveUnittestImport,
+    RemoveUnittestInheritance,
+)
+
+
+def _run(*rules, source: str) -> str:
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+def test_remove_simple_testcase():
+    source = """\
+        import unittest
+
+        class TestFoo(unittest.TestCase):
+            def test_something(self):
+                pass
+        """
+    expected = """\
+        import unittest
+
+        class TestFoo:
+            def test_something(self):
+                pass
+        """
+    result = _run(RemoveUnittestInheritance, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_remove_imported_testcase():
+    source = """\
+        from unittest import TestCase
+
+        class TestFoo(TestCase):
+            def test_something(self):
+                pass
+        """
+    expected = """\
+        from unittest import TestCase
+
+        class TestFoo:
+            def test_something(self):
+                pass
+        """
+    result = _run(RemoveUnittestInheritance, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_remove_async_wrapper():
+    source = """\
+        from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+
+        class TestFoo(IsolatedAsyncioWrapperTestCase):
+            async def test_something(self):
+                pass
+        """
+    expected = """\
+        from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+
+        class TestFoo:
+            async def test_something(self):
+                pass
+        """
+    result = _run(RemoveUnittestInheritance, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_multiple_inheritance_keep_mixin():
+    source = """\
+        from unittest import TestCase
+
+        class TestFoo(SomeMixin, TestCase):
+            def test_something(self):
+                pass
+        """
+    expected = """\
+        from unittest import TestCase
+
+        class TestFoo(SomeMixin):
+            def test_something(self):
+                pass
+        """
+    result = _run(RemoveUnittestInheritance, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_multiple_inheritance_all_unittest():
+    source = """\
+        from unittest import TestCase
+
+        class TestFoo(TestCase):
+            def test_something(self):
+                pass
+        """
+    expected = """\
+        from unittest import TestCase
+
+        class TestFoo:
+            def test_something(self):
+                pass
+        """
+    result = _run(RemoveUnittestInheritance, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_remove_unused_unittest_import():
+    source = """\
+        import unittest
+
+        class TestFoo:
+            def test_something(self):
+                pass
+        """
+    # Erase leaves a blank line where the import was
+    expected = """\
+
+        class TestFoo:
+            def test_something(self):
+                pass
+        """
+    result = _run(RemoveUnittestImport, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_keep_unittest_import_for_mock():
+    source = """\
+        import unittest
+
+        class TestFoo:
+            @unittest.mock.patch("foo.bar")
+            def test_something(self, mock_bar):
+                pass
+        """
+    result = _run(RemoveUnittestImport, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_remove_wrapper_import():
+    source = """\
+        from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+
+        class TestFoo:
+            async def test_something(self):
+                pass
+        """
+    # Erase leaves a blank line where the import was
+    expected = """\
+
+        class TestFoo:
+            async def test_something(self):
+                pass
+        """
+    result = _run(RemoveTestWrapperImport, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_no_change_non_unittest():
+    source = """\
+        class TestFoo(SomeMixin):
+            def test_something(self):
+                pass
+        """
+    result = _run(RemoveUnittestInheritance, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_full_file_transformation():
+    """Complete before/after with multiple classes and all three rules combined."""
+    source = """\
+        import unittest
+        from unittest import TestCase
+        from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+
+        class TestSimple(unittest.TestCase):
+            def test_a(self):
+                pass
+
+        class TestImported(TestCase):
+            def test_b(self):
+                pass
+
+        class TestAsync(IsolatedAsyncioWrapperTestCase):
+            async def test_c(self):
+                pass
+
+        class TestMixed(SomeMixin, TestCase):
+            def test_d(self):
+                pass
+        """
+    # Each erased import leaves a blank line; the Session collapses them to one leading blank line
+    expected = """\
+
+        class TestSimple:
+            def test_a(self):
+                pass
+
+        class TestImported:
+            def test_b(self):
+                pass
+
+        class TestAsync:
+            async def test_c(self):
+                pass
+
+        class TestMixed(SomeMixin):
+            def test_d(self):
+                pass
+        """
+    result = _run(
+        RemoveUnittestInheritance,
+        RemoveUnittestImport,
+        RemoveTestWrapperImport,
+        source=source,
+    )
+    assert result == textwrap.dedent(expected)
+
+
+def test_remove_from_unittest_import_testcase_when_unused():
+    """'from unittest import TestCase' is removed after classes are migrated."""
+    source = """\
+        from unittest import TestCase
+
+        class TestFoo:
+            def test_something(self):
+                pass
+        """
+    # Erase leaves a blank line where the import was
+    expected = """\
+
+        class TestFoo:
+            def test_something(self):
+                pass
+        """
+    result = _run(RemoveUnittestImport, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_combined_inheritance_and_import_removal():
+    """Running all rules together removes both bases and then the now-unused imports."""
+    source = """\
+        import unittest
+        from unittest import TestCase
+
+        class TestFoo(unittest.TestCase):
+            def test_a(self):
+                pass
+
+        class TestBar(TestCase):
+            def test_b(self):
+                pass
+        """
+    # Each erased import leaves a blank line; the Session collapses them to one leading blank line
+    expected = """\
+
+        class TestFoo:
+            def test_a(self):
+                pass
+
+        class TestBar:
+            def test_b(self):
+                pass
+        """
+    result = _run(
+        RemoveUnittestInheritance,
+        RemoveUnittestImport,
+        source=source,
+    )
+    assert result == textwrap.dedent(expected)
+
+
+def test_multiple_inheritance_wrapper():
+    source = textwrap.dedent("""\
+        from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+
+        class TestFoo(SomeMixin, IsolatedAsyncioWrapperTestCase):
+            pass
+    """)
+    result = _run(RemoveUnittestInheritance, RemoveTestWrapperImport, source=source)
+    assert "class TestFoo(SomeMixin):" in result
+    assert "IsolatedAsyncioWrapperTestCase" not in result
+
+
+def test_nested_class_definition():
+    source = textwrap.dedent("""\
+        import unittest
+
+        class OuterTest(unittest.TestCase):
+            class InnerTest(unittest.TestCase):
+                def test_inner(self):
+                    pass
+            def test_outer(self):
+                pass
+    """)
+    result = _run(RemoveUnittestInheritance, RemoveUnittestImport, source=source)
+    assert "class OuterTest:" in result
+    assert "class InnerTest:" in result
+    assert "import unittest" not in result
+
+
+# ---------------------------------------------------------------------------
+# ConvertAssertions tests
+# ---------------------------------------------------------------------------
+
+def _assert(source: str) -> str:
+    """Run only ConvertAssertions on a single dedented statement."""
+    return _run(ConvertAssertions, source=textwrap.dedent(source))
+
+
+def test_convert_assert_equal():
+    result = _assert("self.assertEqual(a, b)\n")
+    assert result == "assert a == b\n"
+
+
+def test_convert_assert_not_equal():
+    result = _assert("self.assertNotEqual(a, b)\n")
+    assert result == "assert a != b\n"
+
+
+def test_convert_assert_true():
+    result = _assert("self.assertTrue(x)\n")
+    assert result == "assert x\n"
+
+
+def test_convert_assert_false():
+    result = _assert("self.assertFalse(x)\n")
+    assert result == "assert not x\n"
+
+
+def test_convert_assert_is():
+    result = _assert("self.assertIs(a, b)\n")
+    assert result == "assert a is b\n"
+
+
+def test_convert_assert_is_not():
+    result = _assert("self.assertIsNot(a, b)\n")
+    assert result == "assert a is not b\n"
+
+
+def test_convert_assert_is_none():
+    result = _assert("self.assertIsNone(x)\n")
+    assert result == "assert x is None\n"
+
+
+def test_convert_assert_is_not_none():
+    result = _assert("self.assertIsNotNone(x)\n")
+    assert result == "assert x is not None\n"
+
+
+def test_convert_assert_in():
+    result = _assert("self.assertIn(a, b)\n")
+    assert result == "assert a in b\n"
+
+
+def test_convert_assert_not_in():
+    result = _assert("self.assertNotIn(a, b)\n")
+    assert result == "assert a not in b\n"
+
+
+def test_convert_assert_is_instance():
+    result = _assert("self.assertIsInstance(a, MyType)\n")
+    assert result == "assert isinstance(a, MyType)\n"
+
+
+def test_convert_assert_almost_equal():
+    result = _assert("self.assertAlmostEqual(a, b)\n")
+    assert result == "assert a == pytest.approx(b)\n"
+
+
+def test_convert_assert_greater():
+    result = _assert("self.assertGreater(a, b)\n")
+    assert result == "assert a > b\n"
+
+
+def test_convert_assert_greater_equal():
+    result = _assert("self.assertGreaterEqual(a, b)\n")
+    assert result == "assert a >= b\n"
+
+
+def test_convert_assert_less():
+    result = _assert("self.assertLess(a, b)\n")
+    assert result == "assert a < b\n"
+
+
+def test_convert_assert_less_equal():
+    result = _assert("self.assertLessEqual(a, b)\n")
+    assert result == "assert a <= b\n"
+
+
+def test_convert_assert_regex():
+    result = _assert("self.assertRegex(s, r)\n")
+    assert result == "assert re.search(r, s)\n"
+
+
+def test_convert_assert_count_equal():
+    result = _assert("self.assertCountEqual(a, b)\n")
+    assert result == "assert sorted(a) == sorted(b)\n"
+
+
+def test_convert_assert_equal_with_message():
+    result = _assert('self.assertEqual(a, b, "mismatch")\n')
+    assert result == 'assert a == b, "mismatch"\n'
+
+
+def test_convert_assert_true_with_msg_kwarg():
+    result = _assert('self.assertTrue(x, msg="should be true")\n')
+    assert result == 'assert x, "should be true"\n'
+
+
+def test_convert_assert_not_equal_with_message():
+    result = _assert('self.assertNotEqual(x, y, "values differ")\n')
+    assert result == 'assert x != y, "values differ"\n'
+
+
+def test_convert_assertions_full_method():
+    """A method with multiple assertion types is fully transformed."""
+    source = """\
+        def test_example(self):
+            self.assertEqual(result, 42)
+            self.assertTrue(flag)
+            self.assertIsNone(value)
+            self.assertIn(item, collection)
+            self.assertGreater(score, 0)
+        """
+    expected = """\
+        def test_example(self):
+            assert result == 42
+            assert flag
+            assert value is None
+            assert item in collection
+            assert score > 0
+        """
+    result = _run(ConvertAssertions, source=source)
+    assert result == textwrap.dedent(expected)
+
+
+def test_no_change_non_self_call():
+    """Calls not on self are not converted."""
+    source = "other.assertEqual(a, b)\n"
+    result = _assert(source)
+    assert result == source
+
+
+def test_no_change_non_assert_method():
+    """Non-assertion self methods are not converted."""
+    source = "self.setUp()\n"
+    result = _assert(source)
+    assert result == source
+
+
+# ---------------------------------------------------------------------------
+# ConvertSetUpTearDown tests
+# ---------------------------------------------------------------------------
+
+def _setup(source: str) -> str:
+    """Run only ConvertSetUpTearDown on a dedented source."""
+    return _run(ConvertSetUpTearDown, source=textwrap.dedent(source))
+
+
+def test_convert_setup():
+    source = """\
+        def setUp(self):
+            self.foo = 1
+        """
+    result = _setup(source)
+    assert "@pytest.fixture(autouse=True)" in result
+    assert "def setup(self):" in result
+    assert "self.foo = 1" in result
+    assert "def setUp" not in result
+
+
+def test_convert_async_setup():
+    source = """\
+        async def asyncSetUp(self):
+            self.foo = await something()
+        """
+    result = _setup(source)
+    assert "@pytest.fixture(autouse=True)" in result
+    assert "async def setup(self):" in result
+    assert "def asyncSetUp" not in result
+
+
+def test_convert_teardown():
+    source = """\
+        def tearDown(self):
+            self.cleanup()
+        """
+    result = _setup(source)
+    assert "@pytest.fixture(autouse=True)" in result
+    assert "def teardown_fixture(self):" in result
+    assert "yield" in result
+    assert "self.cleanup()" in result
+    assert "def tearDown" not in result
+
+
+def test_remove_super_setup():
+    source = """\
+        def setUp(self):
+            super().setUp()
+            self.foo = 1
+        """
+    result = _setup(source)
+    assert "super().setUp()" not in result
+    assert "self.foo = 1" in result
+
+
+def test_remove_maxdiff():
+    source = """\
+        def setUp(self):
+            self.maxDiff = None
+            self.foo = 1
+        """
+    result = _setup(source)
+    assert "self.maxDiff" not in result
+    assert "self.foo = 1" in result
+
+
+# ---------------------------------------------------------------------------
+# ConvertAssertRaises tests
+# ---------------------------------------------------------------------------
+
+def _raises(source: str) -> str:
+    """Run only ConvertAssertRaises on a dedented source."""
+    return _run(ConvertAssertRaises, source=textwrap.dedent(source))
+
+
+def test_convert_assert_raises_basic():
+    source = """\
+        with self.assertRaises(ValueError):
+            do_something()
+        """
+    result = _raises(source)
+    assert "pytest.raises(ValueError)" in result
+    assert "self.assertRaises" not in result
+    assert "do_something()" in result
+
+
+def test_convert_assert_raises_with_as():
+    source = """\
+        with self.assertRaises(TypeError) as cm:
+            do_something()
+        """
+    result = _raises(source)
+    assert "pytest.raises(TypeError)" in result
+    assert "as cm:" in result
+    assert "self.assertRaises" not in result
+
+
+# ---------------------------------------------------------------------------
+# ConvertUnittestDecorators tests
+# ---------------------------------------------------------------------------
+
+def _decorators(source: str) -> str:
+    """Run only ConvertUnittestDecorators on a dedented source."""
+    return _run(ConvertUnittestDecorators, source=textwrap.dedent(source))
+
+
+def test_convert_skip_decorator():
+    source = """\
+        @unittest.skip("not ready")
+        def test_foo(self):
+            pass
+        """
+    result = _decorators(source)
+    assert '@pytest.mark.skip(reason=' in result
+    assert '"not ready"' in result
+    assert "@unittest.skip" not in result
+
+
+def test_convert_skipif_decorator():
+    source = """\
+        @unittest.skipIf(sys.version_info < (3, 10), "needs 3.10")
+        def test_foo(self):
+            pass
+        """
+    result = _decorators(source)
+    assert "pytest.mark.skipif" in result
+    assert "reason=" in result
+    assert "@unittest.skipIf" not in result
+
+
+def test_full_unittest_to_pytest_migration():
+    source = textwrap.dedent("""\
+        import unittest
+        from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+
+
+        class TestCalculator(IsolatedAsyncioWrapperTestCase):
+
+            def setUp(self):
+                self.calc = Calculator()
+
+            def tearDown(self):
+                self.calc.close()
+
+            def test_add(self):
+                self.assertEqual(self.calc.add(1, 2), 3)
+                self.assertTrue(self.calc.is_ready)
+
+            def test_divide_by_zero(self):
+                with self.assertRaises(ZeroDivisionError):
+                    self.calc.divide(1, 0)
+
+            def test_precision(self):
+                self.assertAlmostEqual(self.calc.pi(), 3.14159)
+
+            @unittest.skip("not implemented")
+            def test_future_feature(self):
+                pass
+    """)
+
+    session = Session(ALL_RULES)
+    result = session.run(source)
+
+    # Class inheritance removed
+    assert "class TestCalculator:" in result
+    assert "IsolatedAsyncioWrapperTestCase" not in result
+    assert "import unittest" not in result
+
+    # setUp/tearDown converted
+    assert "@pytest.fixture(autouse=True)" in result
+    assert "def setup(self):" in result
+    assert "def teardown_fixture(self):" in result
+    assert "yield" in result
+
+    # Assertions converted
+    assert "assert self.calc.add(1, 2) == 3" in result
+    assert "assert self.calc.is_ready" in result
+
+    # assertRaises converted
+    assert "with pytest.raises(ZeroDivisionError):" in result
+
+    # assertAlmostEqual converted
+    assert "pytest.approx" in result
+
+    # Decorator converted
+    assert "@pytest.mark.skip" in result
+    assert "unittest.skip" not in result
+
+
+def test_convert_skipunless_decorator():
+    source = """\
+        @unittest.skipUnless(HAS_FEATURE, "needs feature")
+        def test_foo(self):
+            pass
+        """
+    result = _decorators(source)
+    assert "pytest.mark.skipif" in result
+    assert "not HAS_FEATURE" in result
+    assert "reason=" in result
+    assert "@unittest.skipUnless" not in result


### PR DESCRIPTION
7 AST rules covering:
- RemoveUnittestInheritance: strip TestCase/IsolatedAsyncioWrapperTestCase bases
- RemoveUnittestImport: clean up unused unittest imports
- RemoveTestWrapperImport: remove wrapper imports
- ConvertAssertions: 18 self.assertX() → assert conversions
- ConvertSetUpTearDown: setUp/tearDown → pytest fixtures
- ConvertAssertRaises: assertRaises → pytest.raises context manager
- ConvertUnittestDecorators: @unittest.skip → @pytest.mark.skip

49 tests, all passing. Runnable via:
  python -m refactor -d refactor/rules/pytest_migration.py test/