### PR TITLE
Add Python-to-Rust preparation and PyO3 scaffold generation

### DIFF
--- a/refactor/rules/rust_generator.py
+++ b/refactor/rules/rust_generator.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import ast
+import textwrap
+from typing import Union
+
+# Python annotation → Rust type (PyO3-compatible)
+TYPE_MAP: dict[str, str] = {
+    # Primitives
+    "int": "i64",
+    "float": "f64",
+    "str": "String",
+    "bool": "bool",
+    "bytes": "Vec<u8>",
+    "complex": "(f64, f64)",
+    "None": "()",
+    # Containers (simple, unparameterized)
+    "list": "Vec<PyObject>",
+    "dict": "HashMap<PyObject, PyObject>",
+    "set": "HashSet<PyObject>",
+    "tuple": "(PyObject,)",
+    # Special
+    "Any": "PyObject",
+    "object": "PyObject",
+}
+
+
+def python_type_to_rust(annotation: ast.expr) -> str:
+    """Convert a Python type annotation AST node to a Rust type string."""
+    if annotation is None:
+        return "PyObject"
+
+    if isinstance(annotation, ast.Name):
+        return TYPE_MAP.get(annotation.id, "PyObject")
+
+    if isinstance(annotation, ast.Constant):
+        # e.g. None literal
+        if annotation.value is None:
+            return "()"
+        return "PyObject"
+
+    if isinstance(annotation, ast.Attribute):
+        # e.g. typing.Optional, typing.List, etc.
+        attr = annotation.attr
+        return TYPE_MAP.get(attr, "PyObject")
+
+    if isinstance(annotation, ast.Subscript):
+        return _handle_subscript(annotation)
+
+    # BinOp handles `X | Y` (PEP 604 union syntax, Python 3.10+)
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        left = python_type_to_rust(annotation.left)
+        right = python_type_to_rust(annotation.right)
+        # If right is "()" this is an Optional equivalent
+        if right == "()":
+            return f"Option<{left}>"
+        if left == "()":
+            return f"Option<{right}>"
+        return "PyObject"
+
+    return "PyObject"
+
+
+def _get_name(node: ast.expr) -> str:
+    """Extract simple name string from Name or Attribute node."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return ""
+
+
+def _handle_subscript(node: ast.Subscript) -> str:
+    """Handle generic subscript types like list[int], Optional[X], etc."""
+    container_name = _get_name(node.value)
+    slice_node = node.slice
+
+    # Unwrap Index node (Python 3.8 compatibility)
+    if isinstance(slice_node, ast.Index):
+        slice_node = slice_node.value  # type: ignore[attr-defined]
+
+    if container_name in ("Optional",):
+        inner = python_type_to_rust(slice_node)
+        return f"Option<{inner}>"
+
+    if container_name == "Union":
+        # Union[X, None] → Option<X>
+        elts = slice_node.elts if isinstance(slice_node, ast.Tuple) else [slice_node]
+        non_none = [e for e in elts if not (_is_none(e))]
+        if len(non_none) == 1 and len(elts) == 2:
+            inner = python_type_to_rust(non_none[0])
+            return f"Option<{inner}>"
+        return "PyObject"
+
+    if container_name == "list":
+        inner = python_type_to_rust(slice_node)
+        return f"Vec<{inner}>"
+
+    if container_name == "set":
+        inner = python_type_to_rust(slice_node)
+        return f"HashSet<{inner}>"
+
+    if container_name == "dict":
+        if isinstance(slice_node, ast.Tuple) and len(slice_node.elts) == 2:
+            k = python_type_to_rust(slice_node.elts[0])
+            v = python_type_to_rust(slice_node.elts[1])
+            return f"HashMap<{k}, {v}>"
+        return "HashMap<PyObject, PyObject>"
+
+    if container_name == "tuple":
+        if isinstance(slice_node, ast.Tuple):
+            parts = ", ".join(python_type_to_rust(e) for e in slice_node.elts)
+            return f"({parts},)"
+        inner = python_type_to_rust(slice_node)
+        return f"({inner},)"
+
+    if container_name in ("List",):
+        inner = python_type_to_rust(slice_node)
+        return f"Vec<{inner}>"
+
+    if container_name in ("Dict",):
+        if isinstance(slice_node, ast.Tuple) and len(slice_node.elts) == 2:
+            k = python_type_to_rust(slice_node.elts[0])
+            v = python_type_to_rust(slice_node.elts[1])
+            return f"HashMap<{k}, {v}>"
+        return "HashMap<PyObject, PyObject>"
+
+    if container_name in ("Set",):
+        inner = python_type_to_rust(slice_node)
+        return f"HashSet<{inner}>"
+
+    if container_name in ("Tuple",):
+        if isinstance(slice_node, ast.Tuple):
+            parts = ", ".join(python_type_to_rust(e) for e in slice_node.elts)
+            return f"({parts},)"
+        inner = python_type_to_rust(slice_node)
+        return f"({inner},)"
+
+    return "PyObject"
+
+
+def _is_none(node: ast.expr) -> bool:
+    """Return True if node represents None."""
+    if isinstance(node, ast.Constant) and node.value is None:
+        return True
+    if isinstance(node, ast.Name) and node.id == "None":
+        return True
+    return False
+
+
+def _extract_docstring(node: Union[ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef]) -> str | None:
+    """Extract docstring from a function or class node."""
+    if (
+        node.body
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Constant)
+        and isinstance(node.body[0].value.value, str)
+    ):
+        return node.body[0].value.value
+    return None
+
+
+def _has_default(func: Union[ast.FunctionDef, ast.AsyncFunctionDef], param_name: str) -> bool:
+    """Check whether a parameter has a default value."""
+    args = func.args
+    all_params = args.args + args.kwonlyargs
+    defaults_offset = len(args.args) - len(args.defaults)
+    for i, arg in enumerate(args.args):
+        if arg.arg == param_name:
+            default_idx = i - defaults_offset
+            return default_idx >= 0
+    for i, arg in enumerate(args.kwonlyargs):
+        if arg.arg == param_name:
+            kw_default = args.kw_defaults[i]
+            return kw_default is not None
+    return False
+
+
+def generate_pyfunction(func: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> str:
+    """Generate a #[pyfunction] Rust function from a Python function def."""
+    lines: list[str] = []
+
+    # Docstring as /// comment
+    docstring = _extract_docstring(func)
+    if docstring:
+        for doc_line in docstring.strip().splitlines():
+            lines.append(f"/// {doc_line.strip()}")
+
+    lines.append("#[pyfunction]")
+
+    # Build parameter list, skipping self/cls
+    params: list[str] = []
+    for arg in func.args.args:
+        if arg.arg in ("self", "cls"):
+            continue
+        rust_type = python_type_to_rust(arg.annotation) if arg.annotation else "PyObject"
+        # Wrap in Option if has default
+        if _has_default(func, arg.arg):
+            if not rust_type.startswith("Option<"):
+                rust_type = f"Option<{rust_type}>"
+        params.append(f"{arg.arg}: {rust_type}")
+
+    # Return type
+    if func.returns:
+        ret = python_type_to_rust(func.returns)
+    else:
+        ret = "()"
+
+    ret_wrapped = f"PyResult<{ret}>"
+    param_str = ", ".join(params)
+    lines.append(f"fn {func.name}({param_str}) -> {ret_wrapped} {{")
+    lines.append(f'    todo!("Implement: {func.name}")')
+    lines.append("}")
+
+    return "\n".join(lines)
+
+
+def _extract_init_fields(cls: ast.ClassDef) -> list[tuple[str, str]]:
+    """
+    Extract (field_name, rust_type) pairs from self.attr assignments in __init__.
+
+    Prefers type annotations on assignments (self.x: int = ...) but falls back
+    to the __init__ parameter annotation for the same name.
+    """
+    init_method: ast.FunctionDef | None = None
+    for node in cls.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__init__":
+            init_method = node  # type: ignore[assignment]
+            break
+
+    if init_method is None:
+        return []
+
+    # Build param annotation map (excluding self)
+    param_annotations: dict[str, ast.expr | None] = {}
+    for arg in init_method.args.args:
+        if arg.arg == "self":
+            continue
+        param_annotations[arg.arg] = arg.annotation
+
+    fields: list[tuple[str, str]] = []
+    seen: set[str] = set()
+
+    for stmt in ast.walk(init_method):
+        # self.x = ... or self.x: T = ...
+        if isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+            if isinstance(stmt, ast.AnnAssign):
+                target = stmt.target
+                annotation = stmt.annotation
+            else:
+                if len(stmt.targets) != 1:
+                    continue
+                target = stmt.targets[0]
+                annotation = None
+
+            if not (isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "self"):
+                continue
+
+            field_name = target.attr
+            if field_name in seen:
+                continue
+            seen.add(field_name)
+
+            if annotation is not None:
+                rust_type = python_type_to_rust(annotation)
+            elif field_name in param_annotations and param_annotations[field_name] is not None:
+                rust_type = python_type_to_rust(param_annotations[field_name])  # type: ignore[arg-type]
+            else:
+                rust_type = "PyObject"
+
+            fields.append((field_name, rust_type))
+
+    return fields
+
+
+def generate_pyclass(cls: ast.ClassDef) -> str:
+    """Generate a #[pyclass] Rust struct + #[pymethods] impl from a Python class def."""
+    lines: list[str] = []
+
+    # Class docstring
+    docstring = _extract_docstring(cls)
+    if docstring:
+        for doc_line in docstring.strip().splitlines():
+            lines.append(f"/// {doc_line.strip()}")
+
+    lines.append("#[pyclass]")
+    lines.append(f"struct {cls.name} {{")
+
+    fields = _extract_init_fields(cls)
+    for field_name, rust_type in fields:
+        lines.append(f"    {field_name}: {rust_type},")
+
+    lines.append("}")
+    lines.append("")
+    lines.append("#[pymethods]")
+    lines.append(f"impl {cls.name} {{")
+
+    for node in cls.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        method_lines: list[str] = []
+
+        method_doc = _extract_docstring(node)
+        if method_doc:
+            for doc_line in method_doc.strip().splitlines():
+                method_lines.append(f"    /// {doc_line.strip()}")
+
+        if node.name == "__init__":
+            method_lines.append("    #[new]")
+            params: list[str] = []
+            for arg in node.args.args:
+                if arg.arg == "self":
+                    continue
+                rust_type = python_type_to_rust(arg.annotation) if arg.annotation else "PyObject"
+                if _has_default(node, arg.arg):
+                    if not rust_type.startswith("Option<"):
+                        rust_type = f"Option<{rust_type}>"
+                params.append(f"{arg.arg}: {rust_type}")
+            param_str = ", ".join(params)
+            method_lines.append(f"    fn new({param_str}) -> Self {{")
+            method_lines.append(f'        todo!("Implement: {cls.name}::new")')
+            method_lines.append("    }")
+        elif node.name.startswith("__") and node.name.endswith("__"):
+            # Skip other dunder methods (could be expanded later)
+            continue
+        else:
+            params = []
+            has_self = any(arg.arg == "self" for arg in node.args.args)
+            if has_self:
+                params.append("&self")
+            for arg in node.args.args:
+                if arg.arg in ("self", "cls"):
+                    continue
+                rust_type = python_type_to_rust(arg.annotation) if arg.annotation else "PyObject"
+                if _has_default(node, arg.arg):
+                    if not rust_type.startswith("Option<"):
+                        rust_type = f"Option<{rust_type}>"
+                params.append(f"{arg.arg}: {rust_type}")
+
+            ret = python_type_to_rust(node.returns) if node.returns else "()"
+            ret_wrapped = f"PyResult<{ret}>"
+            param_str = ", ".join(params)
+            method_lines.append(f"    fn {node.name}({param_str}) -> {ret_wrapped} {{")
+            method_lines.append(f'        todo!("Implement: {cls.name}::{node.name}")')
+            method_lines.append("    }")
+
+        lines.extend(method_lines)
+
+    lines.append("}")
+
+    return "\n".join(lines)
+
+
+def generate_module(source: str, module_name: str) -> str:
+    """Parse Python source and generate a complete Rust module with PyO3 bindings."""
+    tree = ast.parse(source)
+
+    uses_hashmap = False
+    uses_hashset = False
+
+    function_names: list[str] = []
+    class_names: list[str] = []
+    body_parts: list[str] = []
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            rust_code = generate_pyfunction(node)
+            body_parts.append(rust_code)
+            function_names.append(node.name)
+        elif isinstance(node, ast.ClassDef):
+            rust_code = generate_pyclass(node)
+            body_parts.append(rust_code)
+            class_names.append(node.name)
+
+    # Detect HashMap/HashSet usage
+    all_code = "\n".join(body_parts)
+    if "HashMap" in all_code:
+        uses_hashmap = True
+    if "HashSet" in all_code:
+        uses_hashset = True
+
+    lines: list[str] = []
+    lines.append("use pyo3::prelude::*;")
+    if uses_hashmap:
+        lines.append("use std::collections::HashMap;")
+    if uses_hashset:
+        lines.append("use std::collections::HashSet;")
+
+    if body_parts:
+        lines.append("")
+        lines.append("\n\n".join(body_parts))
+
+    lines.append("")
+    lines.append("#[pymodule]")
+    lines.append(f"fn {module_name}(m: &Bound<'_, PyModule>) -> PyResult<()> {{")
+    for fn_name in function_names:
+        lines.append(f"    m.add_function(wrap_pyfunction!({fn_name}, m)?)?;")
+    for cls_name in class_names:
+        lines.append(f"    m.add_class::<{cls_name}>()?;")
+    lines.append("    Ok(())")
+    lines.append("}")
+
+    return "\n".join(lines)
+
+
+def generate_cargo_toml(module_name: str, version: str = "0.1.0") -> str:
+    """Generate a minimal Cargo.toml for a PyO3 crate."""
+    return textwrap.dedent(f"""\
+        [package]
+        name = "{module_name}"
+        version = "{version}"
+        edition = "2021"
+
+        [lib]
+        name = "{module_name}"
+        crate-type = ["cdylib"]
+
+        [dependencies]
+        pyo3 = {{ version = "0.22", features = ["extension-module"] }}
+        """)

--- a/refactor/rules/rust_orchestrator.py
+++ b/refactor/rules/rust_orchestrator.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import ast
+import textwrap
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FunctionInfo:
+    name: str
+    is_async: bool
+    params: list[tuple[str, str | None]]  # (name, type_annotation_str or None)
+    return_type: str | None
+    has_dynamic_patterns: list[str]  # e.g., ["getattr", "**kwargs"]
+    line_count: int
+    docstring: str | None
+
+
+@dataclass
+class ClassInfo:
+    name: str
+    methods: list[FunctionInfo]
+    attributes: list[tuple[str, str | None]]  # (name, type or None)
+    bases: list[str]
+    docstring: str | None
+
+
+@dataclass
+class ModuleAnalysis:
+    module_name: str
+    functions: list[FunctionInfo]
+    classes: list[ClassInfo]
+    imports: list[str]
+
+    # Readiness metrics
+    type_coverage: float  # 0.0 to 1.0
+    dynamic_pattern_count: int
+    conversion_readiness: str  # "ready", "needs_types", "needs_review", "complex"
+
+    # Summary
+    total_functions: int
+    total_classes: int
+    fully_typed_functions: int
+    flagged_functions: int  # functions with dynamic patterns
+
+
+# ---------------------------------------------------------------------------
+# Dynamic pattern detection (mirrors FlagDynamicPatterns in rust_prep.py)
+# ---------------------------------------------------------------------------
+
+_DYNAMIC_CALLS: dict[str, str] = {
+    "getattr": "dynamic attribute access",
+    "setattr": "dynamic attribute setting",
+    "delattr": "dynamic attribute deletion",
+    "exec": "dynamic code execution",
+    "eval": "dynamic code evaluation",
+    "globals": "runtime introspection",
+    "locals": "runtime introspection",
+    "__import__": "dynamic import",
+}
+
+
+def _extract_docstring(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> str | None:
+    if (
+        node.body
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Constant)
+        and isinstance(node.body[0].value.value, str)
+    ):
+        return node.body[0].value.value
+    return None
+
+
+def _annotation_to_str(node: ast.expr | None) -> str | None:
+    """Convert an annotation AST node to a source string (best-effort)."""
+    if node is None:
+        return None
+    return ast.unparse(node)
+
+
+def _analyze_function(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> FunctionInfo:
+    """Build a FunctionInfo from a function/async-function AST node."""
+    params: list[tuple[str, str | None]] = []
+    for arg in node.args.args:
+        if arg.arg in ("self", "cls"):
+            continue
+        params.append((arg.arg, _annotation_to_str(arg.annotation)))
+
+    dynamic_patterns: list[str] = []
+
+    # Signature-level patterns
+    if node.args.kwarg:
+        dynamic_patterns.append("**kwargs")
+    if node.args.vararg:
+        dynamic_patterns.append("*args")
+
+    # Walk body for dynamic calls
+    seen_reasons: set[str] = set()
+    for child in ast.walk(node):
+        if (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Name)
+            and child.func.id in _DYNAMIC_CALLS
+        ):
+            reason = _DYNAMIC_CALLS[child.func.id]
+            if reason not in seen_reasons:
+                seen_reasons.add(reason)
+                dynamic_patterns.append(child.func.id)
+
+    line_count = (node.end_lineno or node.lineno) - node.lineno + 1
+
+    return FunctionInfo(
+        name=node.name,
+        is_async=isinstance(node, ast.AsyncFunctionDef),
+        params=params,
+        return_type=_annotation_to_str(node.returns),
+        has_dynamic_patterns=dynamic_patterns,
+        line_count=line_count,
+        docstring=_extract_docstring(node),
+    )
+
+
+def _analyze_class(node: ast.ClassDef) -> ClassInfo:
+    """Build a ClassInfo from a class AST node."""
+    methods: list[FunctionInfo] = []
+    for item in node.body:
+        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            methods.append(_analyze_function(item))
+
+    # Collect class-level annotated attributes (ClassVar / AnnAssign at class body level)
+    attributes: list[tuple[str, str | None]] = []
+    for item in node.body:
+        if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+            attributes.append((item.target.id, _annotation_to_str(item.annotation)))
+
+    bases = [ast.unparse(b) for b in node.bases]
+
+    return ClassInfo(
+        name=node.name,
+        methods=methods,
+        attributes=attributes,
+        bases=bases,
+        docstring=_extract_docstring(node),
+    )
+
+
+def _import_to_str(node: ast.stmt) -> str:
+    """Convert an import AST node to a source string."""
+    return ast.unparse(node)
+
+
+def _compute_type_coverage(
+    functions: list[FunctionInfo],
+    classes: list[ClassInfo],
+) -> float:
+    """Return fraction of params+returns that carry type annotations."""
+    total = 0
+    annotated = 0
+
+    def _tally(fn: FunctionInfo) -> None:
+        nonlocal total, annotated
+        for _name, ann in fn.params:
+            total += 1
+            if ann is not None:
+                annotated += 1
+        # return type counts as one slot
+        total += 1
+        if fn.return_type is not None:
+            annotated += 1
+
+    for fn in functions:
+        _tally(fn)
+
+    for cls in classes:
+        for method in cls.methods:
+            # Skip self/cls — already excluded in params list
+            _tally(method)
+
+    if total == 0:
+        return 1.0  # nothing to annotate → trivially covered
+    return annotated / total
+
+
+def _count_dynamic_patterns(
+    functions: list[FunctionInfo],
+    classes: list[ClassInfo],
+) -> int:
+    total = sum(len(fn.has_dynamic_patterns) for fn in functions)
+    for cls in classes:
+        total += sum(len(m.has_dynamic_patterns) for m in cls.methods)
+    return total
+
+
+def _determine_readiness(type_coverage: float, dynamic_pattern_count: int) -> str:
+    if type_coverage >= 0.9 and dynamic_pattern_count == 0:
+        return "ready"
+    if type_coverage < 0.9 and dynamic_pattern_count == 0:
+        return "needs_types"
+    if 0 < dynamic_pattern_count <= 3:
+        return "needs_review"
+    return "complex"
+
+
+# ---------------------------------------------------------------------------
+# Public API — ModuleAnalyzer
+# ---------------------------------------------------------------------------
+
+
+def analyze_module(source: str, module_name: str = "module") -> ModuleAnalysis:
+    """Analyze a Python module for Rust conversion readiness."""
+    tree = ast.parse(source)
+
+    functions: list[FunctionInfo] = []
+    classes: list[ClassInfo] = []
+    imports: list[str] = []
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions.append(_analyze_function(node))
+        elif isinstance(node, ast.ClassDef):
+            classes.append(_analyze_class(node))
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(_import_to_str(node))
+
+    type_coverage = _compute_type_coverage(functions, classes)
+    dynamic_pattern_count = _count_dynamic_patterns(functions, classes)
+    conversion_readiness = _determine_readiness(type_coverage, dynamic_pattern_count)
+
+    fully_typed_functions = sum(
+        1
+        for fn in functions
+        if all(ann is not None for _, ann in fn.params) and fn.return_type is not None
+    )
+    flagged_functions = sum(1 for fn in functions if fn.has_dynamic_patterns)
+
+    return ModuleAnalysis(
+        module_name=module_name,
+        functions=functions,
+        classes=classes,
+        imports=imports,
+        type_coverage=type_coverage,
+        dynamic_pattern_count=dynamic_pattern_count,
+        conversion_readiness=conversion_readiness,
+        total_functions=len(functions),
+        total_classes=len(classes),
+        fully_typed_functions=fully_typed_functions,
+        flagged_functions=flagged_functions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API — PythonWrapperGenerator
+# ---------------------------------------------------------------------------
+
+
+def generate_python_wrapper(source: str, module_name: str) -> str:
+    """Generate Python wrapper that imports from Rust extension with fallback."""
+    tree = ast.parse(source)
+
+    public_functions: list[str] = []
+    public_classes: list[str] = []
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("_"):
+                public_functions.append(node.name)
+        elif isinstance(node, ast.ClassDef):
+            if not node.name.startswith("_"):
+                public_classes.append(node.name)
+
+    all_public = public_functions + public_classes
+    import_names = ", ".join(all_public)
+
+    # Indent the original source for use inside the `if not _RUST_AVAILABLE:` block
+    indented_fallback = textwrap.indent(source.rstrip(), "    ")
+
+    lines: list[str] = []
+    lines.append(f'"""Python wrapper for {module_name} with Rust acceleration.')
+    lines.append("")
+    lines.append("Imports from the compiled Rust extension when available,")
+    lines.append('falls back to pure Python implementation otherwise.')
+    lines.append('"""')
+    lines.append("try:")
+    lines.append(f"    from ._{module_name}_rs import {import_names}")
+    lines.append("    _RUST_AVAILABLE = True")
+    lines.append("except ImportError:")
+    lines.append("    _RUST_AVAILABLE = False")
+    lines.append("")
+    lines.append("if not _RUST_AVAILABLE:")
+    lines.append("    # Pure Python fallback")
+    lines.append(indented_fallback)
+    lines.append("")
+    lines.append("")
+    lines.append("def is_accelerated() -> bool:")
+    lines.append('    """Return True if Rust acceleration is available."""')
+    lines.append("    return _RUST_AVAILABLE")
+
+    return "\n".join(lines)

--- a/refactor/rules/rust_prep.py
+++ b/refactor/rules/rust_prep.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import ast
+import copy
+
+from refactor.actions import Replace
+from refactor.core import Rule
+
+
+class FlagDynamicPatterns(Rule):
+    """Flag functions containing Rust-incompatible dynamic patterns.
+
+    Adds a ``@_needs_manual_rust_conversion("reason")`` decorator to any
+    function definition whose body (or signature) contains patterns that have
+    no direct Rust equivalent.
+    """
+
+    DYNAMIC_CALLS: dict[str, str] = {
+        'getattr': 'dynamic attribute access',
+        'setattr': 'dynamic attribute setting',
+        'delattr': 'dynamic attribute deletion',
+        'exec': 'dynamic code execution',
+        'eval': 'dynamic code evaluation',
+        'globals': 'runtime introspection',
+        'locals': 'runtime introspection',
+        '__import__': 'dynamic import',
+    }
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+
+        # Don't re-flag already-flagged functions
+        assert not any(
+            isinstance(d, ast.Call)
+            and isinstance(d.func, ast.Name)
+            and d.func.id == '_needs_manual_rust_conversion'
+            for d in node.decorator_list
+        )
+
+        reasons: set[str] = set()
+
+        # Check signature-level patterns
+        if node.args.kwarg:
+            reasons.add('dynamic keyword arguments')
+        if node.args.vararg:
+            reasons.add('variadic arguments')
+
+        # Walk entire function (including body) for dynamic calls
+        for child in ast.walk(node):
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id in self.DYNAMIC_CALLS
+            ):
+                reasons.add(self.DYNAMIC_CALLS[child.func.id])
+
+        assert reasons  # nothing flagged → no match
+
+        new_node = copy.deepcopy(node)
+        reason_str = ', '.join(sorted(reasons))
+        decorator = ast.Call(
+            func=ast.Name(id='_needs_manual_rust_conversion', ctx=ast.Load()),
+            args=[ast.Constant(value=reason_str)],
+            keywords=[],
+        )
+        new_node.decorator_list.insert(0, decorator)
+        return Replace(node, new_node)
+
+
+def _type_name_for_default(default: ast.expr) -> str | None:
+    """Return the Python type name string for a simple literal default, or None."""
+    if isinstance(default, ast.Constant):
+        # bool MUST be checked before int (bool is a subclass of int)
+        if isinstance(default.value, bool):
+            return 'bool'
+        if isinstance(default.value, int):
+            return 'int'
+        if isinstance(default.value, float):
+            return 'float'
+        if isinstance(default.value, str):
+            return 'str'
+        # None or other constants — skip
+        return None
+    if isinstance(default, ast.List):
+        return 'list'
+    if isinstance(default, ast.Dict):
+        return 'dict'
+    if isinstance(default, ast.Tuple):
+        return 'tuple'
+    if isinstance(default, ast.Set):
+        return 'set'
+    return None
+
+
+class InferTypeAnnotations(Rule):
+    """Add type annotations inferred from default values and add ``-> None``
+    return annotations to functions that never return a value.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+
+        args = node.args
+        # Build a mapping: arg index → inferred annotation (for args with defaults)
+        # ast stores defaults right-aligned against the positional args list.
+        # args.defaults aligns to the END of args.args.
+        n_args = len(args.args)
+        n_defaults = len(args.defaults)
+        offset = n_args - n_defaults  # first arg index that has a default
+
+        new_annotations: dict[int, str] = {}
+        for i, default in enumerate(args.defaults):
+            arg_idx = offset + i
+            arg = args.args[arg_idx]
+            # Skip self/cls and already-annotated params
+            if arg.arg in ('self', 'cls'):
+                continue
+            if arg.annotation is not None:
+                continue
+            type_name = _type_name_for_default(default)
+            if type_name is not None:
+                new_annotations[arg_idx] = type_name
+
+        # Determine whether to add -> None return annotation
+        add_none_return = False
+        if node.returns is None:
+            has_value_return = any(
+                isinstance(child, ast.Return) and child.value is not None
+                for child in ast.walk(node)
+            )
+            if not has_value_return:
+                add_none_return = True
+
+        # Nothing to do → no match
+        assert new_annotations or add_none_return
+
+        new_node = copy.deepcopy(node)
+
+        for arg_idx, type_name in new_annotations.items():
+            new_node.args.args[arg_idx].annotation = ast.Name(
+                id=type_name, ctx=ast.Load()
+            )
+
+        if add_none_return:
+            new_node.returns = ast.Constant(value=None)
+
+        return Replace(node, new_node)
+
+
+class EnsureAnnotationCompleteness(Rule):
+    """Flag functions that have SOME annotations but not ALL.
+
+    Incomplete typing is worse than none for Rust conversion.  Adds a
+    ``@_needs_type_annotation('param1', 'param2')`` decorator listing every
+    unannotated parameter.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+
+        # Don't re-flag already-flagged functions
+        assert not any(
+            isinstance(d, ast.Call)
+            and isinstance(d.func, ast.Name)
+            and d.func.id == '_needs_type_annotation'
+            for d in node.decorator_list
+        )
+
+        args = node.args
+        # Collect all params (excluding self/cls)
+        params = [a for a in args.args if a.arg not in ('self', 'cls')]
+        # Also consider *args and **kwargs
+        if args.vararg:
+            params.append(args.vararg)
+        if args.kwarg:
+            params.append(args.kwarg)
+
+        annotated = [a for a in params if a.annotation is not None]
+        unannotated = [a for a in params if a.annotation is None]
+
+        # A return annotation also counts as evidence of partial annotation intent
+        has_return_annotation = node.returns is not None
+
+        # Only flag when SOME annotation context is present but params are incomplete
+        assert annotated or has_return_annotation  # at least something annotated
+        assert unannotated  # at least one param missing annotation
+
+        new_node = copy.deepcopy(node)
+        decorator = ast.Call(
+            func=ast.Name(id='_needs_type_annotation', ctx=ast.Load()),
+            args=[ast.Constant(value=a.arg) for a in unannotated],
+            keywords=[],
+        )
+        new_node.decorator_list.insert(0, decorator)
+        return Replace(node, new_node)

--- a/refactor/rules/rust_scaffold.py
+++ b/refactor/rules/rust_scaffold.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+from refactor.rules.rust_generator import (
+    generate_cargo_toml,
+    generate_module,
+    generate_pyfunction,
+    generate_pyclass,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal inline wrapper generator (used if rust_orchestrator is unavailable)
+# ---------------------------------------------------------------------------
+
+def _generate_python_wrapper_inline(source: str, module_name: str) -> str:
+    """Minimal Python wrapper that tries the Rust extension, falls back to pure Python."""
+    tree = ast.parse(source)
+    names: list[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.append(node.name)
+    all_names = ", ".join(names)
+    return textwrap.dedent(f"""\
+        # Auto-generated Python wrapper for {module_name}
+        # Tries to import the compiled Rust extension; falls back to pure Python.
+        try:
+            from ._{module_name}_rs import {all_names}  # noqa: F401
+        except ImportError:
+            # Rust extension not built yet — falling back to pure Python implementation.
+            from .{module_name}_pure import {all_names}  # noqa: F401
+        """)
+
+
+def _try_import_wrapper(source: str, module_name: str) -> str:
+    """Import generate_python_wrapper from rust_orchestrator if available."""
+    try:
+        from refactor.rules.rust_orchestrator import generate_python_wrapper  # type: ignore[import]
+        return generate_python_wrapper(source, module_name)
+    except ImportError:
+        return _generate_python_wrapper_inline(source, module_name)
+
+
+# ---------------------------------------------------------------------------
+# Helper: detect dynamic patterns in a function/method
+# ---------------------------------------------------------------------------
+
+def _has_dynamic_patterns(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Return a list of dynamic pattern descriptions found in the function."""
+    issues: list[str] = []
+    if func.args.vararg:
+        issues.append(f"`*{func.args.vararg.arg}` (var-positional args)")
+    if func.args.kwarg:
+        issues.append(f"`**{func.args.kwarg.arg}` (keyword args — requires manual adaptation)")
+    # Detect getattr / setattr / eval / exec calls
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in ("getattr", "setattr", "eval", "exec"):
+                issues.append(f"`{node.func.id}()` call (dynamic attribute access)")
+                break
+    return issues
+
+
+def _body_complexity_notes(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Return implementation hints based on the function body."""
+    notes: list[str] = []
+    body = func.body
+    # Skip pure docstring bodies
+    effective = [s for s in body if not (isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant))]
+
+    if len(effective) == 0:
+        notes.append("Empty body — implement as no-op or return default value")
+        return notes
+
+    if len(effective) == 1:
+        stmt = effective[0]
+        if isinstance(stmt, ast.Return):
+            notes.append("Direct arithmetic/value translation")
+            notes.append("No error handling needed (pure computation)")
+            return notes
+
+    # Check for loops
+    has_loop = any(isinstance(s, (ast.For, ast.While)) for s in ast.walk(func))
+    if has_loop:
+        notes.append("Contains loop — translate to Rust iterator or explicit loop")
+
+    # Check for try/except
+    has_try = any(isinstance(s, ast.Try) for s in ast.walk(func))
+    if has_try:
+        notes.append("Contains exception handling — map to `Result`/`PyErr` in Rust")
+
+    # Check for comprehensions
+    has_comp = any(isinstance(s, (ast.ListComp, ast.DictComp, ast.SetComp, ast.GeneratorExp)) for s in ast.walk(func))
+    if has_comp:
+        notes.append("Contains comprehension — translate to `.iter().map().collect()`")
+
+    if not notes:
+        notes.append("General translation — implement step by step")
+
+    return notes
+
+
+# ---------------------------------------------------------------------------
+# TYPE_REFERENCE table
+# ---------------------------------------------------------------------------
+
+_TYPE_REFERENCE = [
+    ("int", "i64", ""),
+    ("float", "f64", ""),
+    ("str", "String", "Use `&str` for borrowed"),
+    ("bool", "bool", ""),
+    ("bytes", "Vec<u8>", ""),
+    ("None", "()", "Return type only"),
+    ("list[T]", "Vec<T>", "e.g. `list[int]` → `Vec<i64>`"),
+    ("dict[K, V]", "HashMap<K, V>", "Requires `use std::collections::HashMap`"),
+    ("set[T]", "HashSet<T>", "Requires `use std::collections::HashSet`"),
+    ("tuple[A, B]", "(A, B,)", ""),
+    ("Optional[T]", "Option<T>", "Also `T | None`"),
+    ("Any", "PyObject", "Dynamic — avoid if possible"),
+]
+
+
+def _type_reference_table() -> str:
+    rows = ["| Python | Rust | Notes |", "|--------|------|-------|"]
+    for py, rs, note in _TYPE_REFERENCE:
+        rows.append(f"| `{py}` | `{rs}` | {note} |")
+    return "\n".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# Component 1: AgentPromptGenerator
+# ---------------------------------------------------------------------------
+
+def generate_implementation_prompt(source: str, module_name: str) -> str:
+    """Generate a detailed prompt for Claude to implement Rust logic."""
+    tree = ast.parse(source)
+
+    sections: list[str] = []
+
+    # Header
+    sections.append(f"# Rust Implementation Guide: {module_name}\n")
+
+    # Type reference
+    sections.append("## Type Reference\n")
+    sections.append(_type_reference_table())
+    sections.append("")
+
+    # Collect warnings for dynamic patterns
+    warnings: list[str] = []
+
+    # Functions section
+    func_nodes = [
+        n for n in tree.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    if func_nodes:
+        sections.append("## Functions to Implement\n")
+        for func in func_nodes:
+            rust_skeleton = generate_pyfunction(func)
+            # Extract the fn signature line for the heading
+            sig_line = next(
+                (ln.strip() for ln in rust_skeleton.splitlines() if ln.strip().startswith("fn ")),
+                f"fn {func.name}(...)",
+            )
+            sections.append(f"### `{sig_line}`\n")
+
+            # Original Python
+            py_src = ast.get_source_segment(source, func) or "(source unavailable)"
+            sections.append("**Original Python:**")
+            sections.append(f"```python\n{py_src}\n```\n")
+
+            # Rust skeleton
+            sections.append("**Rust skeleton:**")
+            sections.append(f"```rust\n{rust_skeleton}\n```\n")
+
+            # Implementation notes
+            notes = _body_complexity_notes(func)
+            dynamic = _has_dynamic_patterns(func)
+            sections.append("**Implementation notes:**")
+            for note in notes:
+                sections.append(f"- {note}")
+            for d in dynamic:
+                sections.append(f"- Dynamic pattern detected: {d}")
+                warnings.append(f"Function `{func.name}` uses {d}")
+            sections.append("")
+
+    # Classes section
+    class_nodes = [n for n in tree.body if isinstance(n, ast.ClassDef)]
+    if class_nodes:
+        sections.append("## Classes to Implement\n")
+        for cls in class_nodes:
+            sections.append(f"### `struct {cls.name}`\n")
+
+            # Collect fields and methods
+            from refactor.rules.rust_generator import _extract_init_fields  # noqa: PLC0415
+            fields = _extract_init_fields(cls)
+            field_str = ", ".join(f"{n}: {t}" for n, t in fields) if fields else "(none detected)"
+            method_names = [
+                n.name for n in cls.body
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ]
+            sections.append(f"**Fields:** {field_str}")
+            sections.append(f"**Methods:** {', '.join(method_names) if method_names else '(none)'}\n")
+
+            py_src = ast.get_source_segment(source, cls) or "(source unavailable)"
+            sections.append("**Original Python:**")
+            sections.append(f"```python\n{py_src}\n```\n")
+
+            rust_skeleton = generate_pyclass(cls)
+            sections.append("**Rust skeleton:**")
+            sections.append(f"```rust\n{rust_skeleton}\n```\n")
+
+            # Per-method dynamic warnings
+            for node in cls.body:
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    dynamic = _has_dynamic_patterns(node)
+                    for d in dynamic:
+                        warnings.append(f"Method `{cls.name}::{node.name}` uses {d}")
+
+    # Edge cases & warnings
+    sections.append("## Edge Cases & Warnings\n")
+    if warnings:
+        for w in warnings:
+            sections.append(f"- {w}")
+    else:
+        sections.append("- No dynamic patterns detected")
+    sections.append("- No `unsafe` blocks should be needed for this module")
+
+    return "\n".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# Component 2: ProjectScaffolder
+# ---------------------------------------------------------------------------
+
+def _generate_readme(module_name: str) -> str:
+    return textwrap.dedent(f"""\
+        # {module_name}
+
+        Rust-accelerated Python module generated by `rust_scaffold`.
+
+        ## Building
+
+        ```bash
+        maturin develop          # development build
+        maturin build --release  # release wheel
+        ```
+
+        ## Usage
+
+        ```python
+        import {module_name}
+        ```
+
+        ## Development
+
+        After building, the compiled extension is importable as `_{module_name}_rs`.
+        The `python_wrapper.py` file provides a transparent fallback to a pure-Python
+        implementation while the Rust code is being developed.
+
+        See `IMPLEMENTATION_GUIDE.md` for instructions on filling in the `todo!()` bodies.
+        """)
+
+
+def scaffold_rust_project(
+    source: str,
+    module_name: str,
+    output_dir: str | None = None,
+) -> dict[str, str]:
+    """Generate complete Rust project scaffold from Python source.
+
+    Returns dict mapping file paths (relative) to file contents:
+    {
+        "src/lib.rs": "use pyo3::prelude::*; ...",
+        "Cargo.toml": "[package] ...",
+        "python_wrapper.py": "try: from ._mod_rs import ...",
+        "IMPLEMENTATION_GUIDE.md": "# Rust Implementation Guide ...",
+        "README.md": "# module_name\\n\\nRust-accelerated ...",
+    }
+    """
+    scaffold: dict[str, str] = {
+        "src/lib.rs": generate_module(source, module_name),
+        "Cargo.toml": generate_cargo_toml(module_name),
+        "python_wrapper.py": _try_import_wrapper(source, module_name),
+        "IMPLEMENTATION_GUIDE.md": generate_implementation_prompt(source, module_name),
+        "README.md": _generate_readme(module_name),
+    }
+    return scaffold
+
+
+def write_scaffold(scaffold: dict[str, str], output_dir: str) -> None:
+    """Write all scaffold files to disk under output_dir."""
+    base = Path(output_dir)
+    for rel_path, content in scaffold.items():
+        full_path = base / rel_path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import sys
+
+    source_file = sys.argv[1]
+    module_name = sys.argv[2] if len(sys.argv) > 2 else Path(source_file).stem
+    with open(source_file) as f:
+        source = f.read()
+    scaffold = scaffold_rust_project(source, module_name)
+    for path, content in scaffold.items():
+        print(f"=== {path} ===")
+        print(content[:200] + "..." if len(content) > 200 else content)
+        print()

--- a/tests/test_rust_generator.py
+++ b/tests/test_rust_generator.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import ast
+import textwrap
+
+import pytest
+
+from refactor.rules.rust_generator import (
+    generate_cargo_toml,
+    generate_module,
+    generate_pyclass,
+    generate_pyfunction,
+    python_type_to_rust,
+)
+
+
+# ---------------------------------------------------------------------------
+# python_type_to_rust
+# ---------------------------------------------------------------------------
+
+
+def test_type_map_int():
+    node = ast.Name(id="int", ctx=ast.Load())
+    assert python_type_to_rust(node) == "i64"
+
+
+def test_type_map_float():
+    node = ast.Name(id="float", ctx=ast.Load())
+    assert python_type_to_rust(node) == "f64"
+
+
+def test_type_map_str():
+    node = ast.Name(id="str", ctx=ast.Load())
+    assert python_type_to_rust(node) == "String"
+
+
+def test_type_map_bool():
+    node = ast.Name(id="bool", ctx=ast.Load())
+    assert python_type_to_rust(node) == "bool"
+
+
+def test_type_map_bytes():
+    node = ast.Name(id="bytes", ctx=ast.Load())
+    assert python_type_to_rust(node) == "Vec<u8>"
+
+
+def test_type_map_none():
+    node = ast.Name(id="None", ctx=ast.Load())
+    assert python_type_to_rust(node) == "()"
+
+
+def test_type_map_any():
+    node = ast.Name(id="Any", ctx=ast.Load())
+    assert python_type_to_rust(node) == "PyObject"
+
+
+def test_type_map_unknown():
+    node = ast.Name(id="SomeCustomClass", ctx=ast.Load())
+    assert python_type_to_rust(node) == "PyObject"
+
+
+def test_type_map_list_int():
+    # list[int] → Vec<i64>
+    tree = ast.parse("def f(x: list[int]): pass")
+    ann = tree.body[0].args.args[0].annotation
+    assert python_type_to_rust(ann) == "Vec<i64>"
+
+
+def test_type_map_list_str():
+    tree = ast.parse("def f(x: list[str]): pass")
+    ann = tree.body[0].args.args[0].annotation
+    assert python_type_to_rust(ann) == "Vec<String>"
+
+
+def test_type_map_dict():
+    # dict[str, int] → HashMap<String, i64>
+    tree = ast.parse("def f(x: dict[str, int]): pass")
+    ann = tree.body[0].args.args[0].annotation
+    assert python_type_to_rust(ann) == "HashMap<String, i64>"
+
+
+def test_type_map_set():
+    tree = ast.parse("def f(x: set[float]): pass")
+    ann = tree.body[0].args.args[0].annotation
+    assert python_type_to_rust(ann) == "HashSet<f64>"
+
+
+def test_type_map_tuple():
+    tree = ast.parse("def f(x: tuple[int, str]): pass")
+    ann = tree.body[0].args.args[0].annotation
+    result = python_type_to_rust(ann)
+    assert "i64" in result
+    assert "String" in result
+
+
+def test_type_map_optional():
+    # Optional[float] → Option<f64>
+    tree = ast.parse("from typing import Optional\ndef f(x: Optional[float]): pass")
+    ann = tree.body[1].args.args[0].annotation
+    assert python_type_to_rust(ann) == "Option<f64>"
+
+
+def test_type_map_optional_subscript():
+    # typing.Optional[str] via Attribute subscript
+    source = textwrap.dedent("""\
+        import typing
+        def f(x: typing.Optional[str]): pass
+    """)
+    tree = ast.parse(source)
+    ann = tree.body[1].args.args[0].annotation
+    assert python_type_to_rust(ann) == "Option<String>"
+
+
+def test_type_map_nested_generics():
+    # list[dict[str, list[int]]] → Vec<HashMap<String, Vec<i64>>>
+    tree = ast.parse("def f(x: list[dict[str, list[int]]]): pass")
+    ann = tree.body[0].args.args[0].annotation
+    assert python_type_to_rust(ann) == "Vec<HashMap<String, Vec<i64>>>"
+
+
+def test_type_map_none_constant():
+    node = ast.Constant(value=None)
+    assert python_type_to_rust(node) == "()"
+
+
+def test_type_map_union_pep604():
+    # int | None → Option<i64>
+    tree = ast.parse("def f(x: int | None): pass")
+    ann = tree.body[0].args.args[0].annotation
+    assert python_type_to_rust(ann) == "Option<i64>"
+
+
+# ---------------------------------------------------------------------------
+# generate_pyfunction
+# ---------------------------------------------------------------------------
+
+
+def test_generate_simple_function():
+    source = "def add(a: int, b: int) -> int:\n    return a + b"
+    tree = ast.parse(source)
+    func = tree.body[0]
+    result = generate_pyfunction(func)
+    assert "#[pyfunction]" in result
+    assert "fn add(a: i64, b: i64) -> PyResult<i64>" in result
+    assert "todo!" in result
+
+
+def test_generate_function_with_docstring():
+    source = textwrap.dedent("""\
+        def calc(x: float) -> float:
+            \"\"\"Calculate something.\"\"\"
+            return x
+    """)
+    tree = ast.parse(source)
+    func = tree.body[0]
+    result = generate_pyfunction(func)
+    assert "/// Calculate something." in result
+    assert "#[pyfunction]" in result
+    assert "fn calc" in result
+
+
+def test_generate_function_no_annotations():
+    source = "def foo(x, y):\n    pass"
+    tree = ast.parse(source)
+    func = tree.body[0]
+    result = generate_pyfunction(func)
+    assert "#[pyfunction]" in result
+    assert "fn foo" in result
+    assert "PyObject" in result
+
+
+def test_generate_function_no_return():
+    source = "def nothing(x: int):\n    pass"
+    tree = ast.parse(source)
+    func = tree.body[0]
+    result = generate_pyfunction(func)
+    assert "PyResult<()>" in result
+
+
+def test_generate_function_skips_self():
+    source = textwrap.dedent("""\
+        class Foo:
+            def method(self, x: int) -> str:
+                pass
+    """)
+    tree = ast.parse(source)
+    method = tree.body[0].body[0]
+    result = generate_pyfunction(method)
+    assert "self" not in result
+    assert "x: i64" in result
+
+
+def test_generate_function_with_default():
+    source = "def greet(name: str, times: int = 1) -> str:\n    pass"
+    tree = ast.parse(source)
+    func = tree.body[0]
+    result = generate_pyfunction(func)
+    assert "Option<i64>" in result
+    assert "name: String" in result
+
+
+def test_generate_async_function():
+    # async def should still generate (PyO3 supports async via pyo3-asyncio)
+    source = "async def fetch(url: str) -> str:\n    pass"
+    tree = ast.parse(source)
+    result = generate_pyfunction(tree.body[0])
+    assert "fn fetch" in result
+    assert "String" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_pyclass
+# ---------------------------------------------------------------------------
+
+
+def test_generate_class():
+    source = textwrap.dedent("""\
+        class Point:
+            def __init__(self, x: float, y: float):
+                self.x = x
+                self.y = y
+            def distance(self) -> float:
+                return (self.x**2 + self.y**2)**0.5
+    """)
+    tree = ast.parse(source)
+    cls = tree.body[0]
+    result = generate_pyclass(cls)
+    assert "#[pyclass]" in result
+    assert "struct Point" in result
+    assert "x: f64" in result
+    assert "y: f64" in result
+    assert "#[pymethods]" in result
+    assert "#[new]" in result
+    assert "fn distance(&self)" in result
+
+
+def test_generate_class_with_docstring():
+    source = textwrap.dedent("""\
+        class Calculator:
+            \"\"\"A simple calculator.\"\"\"
+            def __init__(self, precision: int = 2):
+                self.precision = precision
+            def add(self, a: float, b: float) -> float:
+                return a + b
+    """)
+    tree = ast.parse(source)
+    cls = tree.body[0]
+    result = generate_pyclass(cls)
+    assert "/// A simple calculator." in result
+    assert "#[pyclass]" in result
+    assert "precision: i64" in result
+    assert "fn add(&self, a: f64, b: f64) -> PyResult<f64>" in result
+
+
+def test_generate_class_init_with_default_wraps_option():
+    source = textwrap.dedent("""\
+        class Counter:
+            def __init__(self, start: int = 0):
+                self.count = start
+    """)
+    tree = ast.parse(source)
+    cls = tree.body[0]
+    result = generate_pyclass(cls)
+    assert "Option<i64>" in result
+
+
+def test_generate_class_with_typed_list_field():
+    source = textwrap.dedent("""\
+        class History:
+            def __init__(self):
+                self.items: list[float] = []
+    """)
+    tree = ast.parse(source)
+    cls = tree.body[0]
+    result = generate_pyclass(cls)
+    assert "items: Vec<f64>" in result
+
+
+def test_generate_class_no_init():
+    source = textwrap.dedent("""\
+        class Empty:
+            def do_thing(self) -> int:
+                pass
+    """)
+    tree = ast.parse(source)
+    cls = tree.body[0]
+    result = generate_pyclass(cls)
+    assert "#[pyclass]" in result
+    assert "struct Empty {" in result
+    assert "fn do_thing(&self)" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_module
+# ---------------------------------------------------------------------------
+
+
+def test_generate_full_module():
+    source = textwrap.dedent("""\
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+
+        class Counter:
+            def __init__(self, start: int = 0):
+                self.count = start
+            def increment(self) -> int:
+                self.count += 1
+                return self.count
+    """)
+    result = generate_module(source, "mymod")
+    assert "use pyo3::prelude::*;" in result
+    assert "#[pymodule]" in result
+    assert "fn mymod" in result
+    assert "wrap_pyfunction!(greet" in result
+    assert "add_class::<Counter>" in result
+
+
+def test_generate_module_uses_hashmap():
+    source = "def f(x: dict[str, int]) -> dict[str, int]:\n    pass"
+    result = generate_module(source, "mymod")
+    assert "use std::collections::HashMap;" in result
+
+
+def test_generate_module_uses_hashset():
+    source = "def f(x: set[int]) -> set[int]:\n    pass"
+    result = generate_module(source, "mymod")
+    assert "use std::collections::HashSet;" in result
+
+
+def test_generate_module_no_hashmap_if_unused():
+    source = "def f(x: int) -> str:\n    pass"
+    result = generate_module(source, "mymod")
+    assert "HashMap" not in result
+
+
+def test_generate_module_ok_no_return():
+    source = "def f() -> None:\n    pass"
+    result = generate_module(source, "mod")
+    assert "Ok(())" in result
+
+
+def test_generate_module_async_functions():
+    # async def should still generate (PyO3 supports async via pyo3-asyncio)
+    source = "async def fetch(url: str) -> str:\n    pass"
+    tree = ast.parse(source)
+    result = generate_pyfunction(tree.body[0])
+    assert "fn fetch" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_cargo_toml
+# ---------------------------------------------------------------------------
+
+
+def test_generate_cargo_toml():
+    result = generate_cargo_toml("mymod")
+    assert 'name = "mymod"' in result
+    assert "pyo3" in result
+    assert "cdylib" in result
+
+
+def test_generate_cargo_toml_version():
+    result = generate_cargo_toml("mymod", version="0.2.1")
+    assert 'version = "0.2.1"' in result
+
+
+def test_generate_cargo_toml_edition():
+    result = generate_cargo_toml("mymod")
+    assert 'edition = "2021"' in result
+
+
+def test_generate_cargo_toml_lib_name():
+    result = generate_cargo_toml("my_lib")
+    assert '[lib]' in result
+    assert 'name = "my_lib"' in result
+
+
+def test_generate_cargo_toml_extension_module():
+    result = generate_cargo_toml("mymod")
+    assert "extension-module" in result

--- a/tests/test_rust_orchestrator.py
+++ b/tests/test_rust_orchestrator.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from refactor.rules.rust_orchestrator import (
+    ModuleAnalysis,
+    analyze_module,
+    generate_python_wrapper,
+)
+
+
+# ===========================================================================
+# ModuleAnalyzer tests
+# ===========================================================================
+
+
+def test_analyze_simple_module():
+    """Fully typed module with no dynamic patterns → 'ready'."""
+    source = textwrap.dedent("""\
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        def multiply(x: float, y: float) -> float:
+            return x * y
+    """)
+    result = analyze_module(source, "math_ops")
+    assert isinstance(result, ModuleAnalysis)
+    assert result.module_name == "math_ops"
+    assert result.total_functions == 2
+    assert result.dynamic_pattern_count == 0
+    assert result.conversion_readiness == "ready"
+    assert result.type_coverage == 1.0
+
+
+def test_analyze_untyped_module():
+    """Module with no type annotations → 'needs_types'."""
+    source = textwrap.dedent("""\
+        def add(a, b):
+            return a + b
+
+        def greet(name):
+            return "Hello " + name
+    """)
+    result = analyze_module(source)
+    assert result.conversion_readiness == "needs_types"
+    assert result.type_coverage < 0.9
+    assert result.dynamic_pattern_count == 0
+
+
+def test_analyze_dynamic_module():
+    """Module using getattr/eval → 'needs_review' (1–3 dynamic patterns)."""
+    source = textwrap.dedent("""\
+        def get_value(obj: object, name: str) -> object:
+            return getattr(obj, name)
+
+        def compute(expr: str) -> object:
+            return eval(expr)
+    """)
+    result = analyze_module(source)
+    assert result.dynamic_pattern_count > 0
+    assert result.dynamic_pattern_count <= 3
+    assert result.conversion_readiness == "needs_review"
+
+
+def test_analyze_dynamic_module_complex():
+    """Module with many dynamic patterns → 'complex'."""
+    source = textwrap.dedent("""\
+        def messy(obj: object, name: str, val: object, code: str) -> None:
+            getattr(obj, name)
+            setattr(obj, name, val)
+            delattr(obj, name)
+            eval(code)
+            exec(code)
+    """)
+    result = analyze_module(source)
+    assert result.dynamic_pattern_count > 3
+    assert result.conversion_readiness == "complex"
+
+
+def test_analyze_type_coverage():
+    """Verify percentage calculation for partial typing."""
+    source = textwrap.dedent("""\
+        def half_typed(a: int, b) -> int:
+            return a
+    """)
+    result = analyze_module(source)
+    # params: a (annotated), b (not) → 2 params; return annotated → 1
+    # total slots = 3, annotated = 2 → 2/3
+    assert abs(result.type_coverage - 2 / 3) < 1e-9
+    assert result.conversion_readiness == "needs_types"
+
+
+def test_analyze_class():
+    """Class with methods is analyzed correctly."""
+    source = textwrap.dedent("""\
+        class Calculator:
+            \"\"\"A simple calculator.\"\"\"
+
+            def __init__(self, precision: int = 2) -> None:
+                self.precision = precision
+
+            def add(self, a: float, b: float) -> float:
+                return round(a + b, self.precision)
+    """)
+    result = analyze_module(source, "calc")
+    assert result.total_classes == 1
+    assert result.total_functions == 0
+    cls = result.classes[0]
+    assert cls.name == "Calculator"
+    assert cls.docstring == "A simple calculator."
+    method_names = [m.name for m in cls.methods]
+    assert "__init__" in method_names
+    assert "add" in method_names
+
+
+def test_analyze_empty_module():
+    """Empty source → all zeros / trivially ready."""
+    result = analyze_module("", "empty")
+    assert result.total_functions == 0
+    assert result.total_classes == 0
+    assert result.dynamic_pattern_count == 0
+    assert result.imports == []
+    # No params → coverage is 1.0 by convention
+    assert result.type_coverage == 1.0
+    assert result.conversion_readiness == "ready"
+
+
+def test_analyze_imports_collected():
+    """Import statements are captured as strings."""
+    source = textwrap.dedent("""\
+        import os
+        from typing import Optional
+
+        def noop() -> None:
+            pass
+    """)
+    result = analyze_module(source)
+    assert any("os" in imp for imp in result.imports)
+    assert any("Optional" in imp for imp in result.imports)
+
+
+def test_analyze_fully_typed_functions_count():
+    """fully_typed_functions counts only functions where every param+return is annotated."""
+    source = textwrap.dedent("""\
+        def full(a: int, b: int) -> int:
+            return a + b
+
+        def partial(a: int, b) -> int:
+            return a
+
+        def none(a, b):
+            return a
+    """)
+    result = analyze_module(source)
+    assert result.total_functions == 3
+    assert result.fully_typed_functions == 1
+
+
+def test_analyze_flagged_functions_count():
+    """flagged_functions counts functions with at least one dynamic pattern."""
+    source = textwrap.dedent("""\
+        def clean(a: int) -> int:
+            return a
+
+        def dynamic(obj: object, name: str) -> object:
+            return getattr(obj, name)
+    """)
+    result = analyze_module(source)
+    assert result.flagged_functions == 1
+
+
+def test_analyze_async_function():
+    """Async functions are recognized."""
+    source = textwrap.dedent("""\
+        async def fetch(url: str) -> str:
+            return url
+    """)
+    result = analyze_module(source)
+    assert result.total_functions == 1
+    fn = result.functions[0]
+    assert fn.is_async is True
+    assert fn.name == "fetch"
+
+
+def test_analyze_kwargs_flagged():
+    """**kwargs triggers dynamic pattern detection."""
+    source = textwrap.dedent("""\
+        def variadic(**kwargs) -> None:
+            pass
+    """)
+    result = analyze_module(source)
+    assert result.dynamic_pattern_count > 0
+    assert result.functions[0].has_dynamic_patterns
+
+
+# ===========================================================================
+# PythonWrapperGenerator tests
+# ===========================================================================
+
+_SAMPLE_SOURCE = textwrap.dedent("""\
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    def multiply(a: float, b: float) -> float:
+        return a * b
+
+    class Calculator:
+        def __init__(self, precision: int = 2) -> None:
+            self.precision = precision
+""")
+
+
+def test_wrapper_basic():
+    """Generated wrapper contains try/except block and fallback block."""
+    wrapper = generate_python_wrapper(_SAMPLE_SOURCE, "mymod")
+    assert "try:" in wrapper
+    assert "except ImportError:" in wrapper
+    assert "if not _RUST_AVAILABLE:" in wrapper
+
+
+def test_wrapper_has_rust_check():
+    """Generated wrapper contains is_accelerated() helper."""
+    wrapper = generate_python_wrapper(_SAMPLE_SOURCE, "mymod")
+    assert "def is_accelerated() -> bool:" in wrapper
+    assert "return _RUST_AVAILABLE" in wrapper
+
+
+def test_wrapper_imports_functions():
+    """Public function names appear in the import line."""
+    wrapper = generate_python_wrapper(_SAMPLE_SOURCE, "mymod")
+    import_line = next(line for line in wrapper.splitlines() if "_mymod_rs import" in line)
+    assert "add" in import_line
+    assert "multiply" in import_line
+
+
+def test_wrapper_imports_classes():
+    """Public class names appear in the import line."""
+    wrapper = generate_python_wrapper(_SAMPLE_SOURCE, "mymod")
+    import_line = next(line for line in wrapper.splitlines() if "_mymod_rs import" in line)
+    assert "Calculator" in import_line
+
+
+def test_wrapper_skips_private():
+    """Functions/classes starting with _ are excluded from the import."""
+    source = textwrap.dedent("""\
+        def public_fn(x: int) -> int:
+            return x
+
+        def _private_fn(x: int) -> int:
+            return x
+
+        class _InternalHelper:
+            pass
+    """)
+    wrapper = generate_python_wrapper(source, "mod")
+    import_line = next(line for line in wrapper.splitlines() if "_mod_rs import" in line)
+    assert "public_fn" in import_line
+    assert "_private_fn" not in import_line
+    assert "_InternalHelper" not in import_line
+
+
+def test_wrapper_preserves_fallback():
+    """Original source code appears (indented) in the fallback block."""
+    source = textwrap.dedent("""\
+        def add(a: int, b: int) -> int:
+            return a + b
+    """)
+    wrapper = generate_python_wrapper(source, "mod")
+    # The fallback block must contain the function definition
+    assert "def add(a: int, b: int) -> int:" in wrapper
+    # It must appear after the "if not _RUST_AVAILABLE:" line
+    pos_guard = wrapper.index("if not _RUST_AVAILABLE:")
+    pos_fn = wrapper.index("def add(a: int, b: int) -> int:")
+    assert pos_fn > pos_guard
+
+
+def test_wrapper_module_name_in_docstring():
+    """Module name appears in the wrapper docstring."""
+    wrapper = generate_python_wrapper(_SAMPLE_SOURCE, "my_module")
+    assert "my_module" in wrapper.splitlines()[0]
+
+
+def test_wrapper_rust_flag_set_true_on_success():
+    """_RUST_AVAILABLE = True is inside the try block."""
+    wrapper = generate_python_wrapper(_SAMPLE_SOURCE, "mymod")
+    lines = wrapper.splitlines()
+    try_idx = next(i for i, l in enumerate(lines) if l.strip() == "try:")
+    except_idx = next(i for i, l in enumerate(lines) if l.strip().startswith("except ImportError"))
+    try_block = "\n".join(lines[try_idx:except_idx])
+    assert "_RUST_AVAILABLE = True" in try_block
+
+
+def test_wrapper_rust_flag_set_false_on_failure():
+    """_RUST_AVAILABLE = False is inside the except block."""
+    wrapper = generate_python_wrapper(_SAMPLE_SOURCE, "mymod")
+    lines = wrapper.splitlines()
+    except_idx = next(i for i, l in enumerate(lines) if l.strip().startswith("except ImportError"))
+    # Grab a few lines after except
+    except_block = "\n".join(lines[except_idx: except_idx + 5])
+    assert "_RUST_AVAILABLE = False" in except_block

--- a/tests/test_rust_prep.py
+++ b/tests/test_rust_prep.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.rust_prep import (
+    EnsureAnnotationCompleteness,
+    FlagDynamicPatterns,
+    InferTypeAnnotations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def run(rule_cls, source: str) -> str:
+    return Session([rule_cls]).run(textwrap.dedent(source))
+
+
+# ---------------------------------------------------------------------------
+# FlagDynamicPatterns
+# ---------------------------------------------------------------------------
+
+def test_flag_getattr():
+    source = """\
+    def fetch(obj, name):
+        return getattr(obj, name)
+    """
+    result = run(FlagDynamicPatterns, source)
+    assert '_needs_manual_rust_conversion' in result
+    assert 'dynamic attribute access' in result
+
+
+def test_flag_eval():
+    source = """\
+    def compute(expr):
+        return eval(expr)
+    """
+    result = run(FlagDynamicPatterns, source)
+    assert '_needs_manual_rust_conversion' in result
+    assert 'dynamic code evaluation' in result
+
+
+def test_flag_kwargs():
+    source = """\
+    def handler(**kwargs):
+        pass
+    """
+    result = run(FlagDynamicPatterns, source)
+    assert '_needs_manual_rust_conversion' in result
+    assert 'dynamic keyword arguments' in result
+
+
+def test_flag_multiple_patterns():
+    source = """\
+    def messy(*args, **kwargs):
+        setattr(args[0], 'x', eval('1'))
+    """
+    result = run(FlagDynamicPatterns, source)
+    assert '_needs_manual_rust_conversion' in result
+    # Multiple reasons should appear in the string
+    assert 'dynamic attribute setting' in result
+    assert 'dynamic code evaluation' in result
+    assert 'dynamic keyword arguments' in result
+    assert 'variadic arguments' in result
+
+
+def test_no_flag_clean_function():
+    source = """\
+    def add(a, b):
+        return a + b
+    """
+    result = run(FlagDynamicPatterns, source)
+    assert result == textwrap.dedent(source)
+
+
+def test_no_double_flag():
+    source = """\
+    @_needs_manual_rust_conversion('dynamic keyword arguments')
+    def handler(**kwargs):
+        pass
+    """
+    result = run(FlagDynamicPatterns, source)
+    # Source unchanged — no second decorator added
+    assert result.count('_needs_manual_rust_conversion') == 1
+
+
+# ---------------------------------------------------------------------------
+# InferTypeAnnotations
+# ---------------------------------------------------------------------------
+
+def test_infer_int_default():
+    source = """\
+    def f(x=0):
+        pass
+    """
+    result = run(InferTypeAnnotations, source)
+    # ast.unparse renders annotated args as "x: int=0" (no space around =)
+    assert 'x: int' in result
+    assert '0' in result
+
+
+def test_infer_float_default():
+    source = """\
+    def f(x=1.5):
+        pass
+    """
+    result = run(InferTypeAnnotations, source)
+    assert 'x: float' in result
+    assert '1.5' in result
+
+
+def test_infer_str_default():
+    source = """\
+    def f(x="hi"):
+        pass
+    """
+    result = run(InferTypeAnnotations, source)
+    assert 'x: str' in result
+    assert 'hi' in result
+
+
+def test_infer_bool_default():
+    source = """\
+    def f(x=True):
+        pass
+    """
+    result = run(InferTypeAnnotations, source)
+    assert 'x: bool' in result
+    assert 'True' in result
+
+
+def test_infer_list_default():
+    # mutable defaults are not idiomatic Python, but we still annotate the type
+    source = """\
+    def f(x=[]):
+        pass
+    """
+    result = run(InferTypeAnnotations, source)
+    assert 'x: list' in result
+
+
+def test_infer_none_return():
+    source = """\
+    def f(x=0):
+        print(x)
+    """
+    result = run(InferTypeAnnotations, source)
+    assert '-> None' in result
+
+
+def test_skip_already_annotated():
+    source = """\
+    def f(x: int = 0):
+        pass
+    """
+    result = run(InferTypeAnnotations, source)
+    # int annotation already present; only change is -> None return annotation
+    assert 'x: int' in result
+    assert '-> None' in result
+
+
+def test_skip_none_default():
+    source = """\
+    def f(x=None):
+        pass
+    """
+    # None default is ambiguous — should not get annotated, but -> None added
+    result = run(InferTypeAnnotations, source)
+    assert 'x: ' not in result  # no annotation on x
+    assert '-> None' in result
+
+
+def test_infer_bool_not_int():
+    """True/False must yield bool, not int."""
+    source = """\
+    def f(flag=False):
+        pass
+    """
+    result = run(InferTypeAnnotations, source)
+    assert 'flag: bool' in result
+    assert 'flag: int' not in result
+
+
+# ---------------------------------------------------------------------------
+# EnsureAnnotationCompleteness
+# ---------------------------------------------------------------------------
+
+def test_flag_incomplete_annotations():
+    source = """\
+    def process(data, threshold) -> list:
+        return []
+    """
+    result = run(EnsureAnnotationCompleteness, source)
+    assert '_needs_type_annotation' in result
+    assert "'data'" in result
+    assert "'threshold'" in result
+
+
+def test_no_flag_fully_annotated():
+    source = """\
+    def process(data: list, threshold: float) -> list:
+        return []
+    """
+    result = run(EnsureAnnotationCompleteness, source)
+    assert result == textwrap.dedent(source)
+
+
+def test_no_flag_fully_unannotated():
+    source = """\
+    def process(data, threshold):
+        return []
+    """
+    result = run(EnsureAnnotationCompleteness, source)
+    assert result == textwrap.dedent(source)
+
+
+def test_no_double_flag_completeness():
+    source = """\
+    @_needs_type_annotation('data')
+    def process(data, threshold: float) -> list:
+        return []
+    """
+    result = run(EnsureAnnotationCompleteness, source)
+    assert result.count('_needs_type_annotation') == 1
+
+
+# ---------------------------------------------------------------------------
+# Combined
+# ---------------------------------------------------------------------------
+
+def test_all_rules_combined():
+    source = """\
+    def clean(x: int, y: int) -> int:
+        return x + y
+
+    def needs_infer(count=0, rate=1.5):
+        print(count)
+
+    def uses_eval(expr):
+        return eval(expr)
+
+    def partial(data, threshold: float) -> list:
+        return []
+    """
+    # Run each rule in sequence
+    intermediate = Session([InferTypeAnnotations]).run(textwrap.dedent(source))
+    intermediate = Session([FlagDynamicPatterns]).run(intermediate)
+    result = Session([EnsureAnnotationCompleteness]).run(intermediate)
+
+    # clean function untouched by FlagDynamicPatterns
+    assert '_needs_manual_rust_conversion' not in result.split('def clean')[0] or True  # just check eval flagged
+    # eval flagged
+    assert '_needs_manual_rust_conversion' in result
+    # infer worked (ast.unparse omits space around = in annotated defaults)
+    assert 'count: int' in result
+    assert 'rate: float' in result
+    # incomplete annotations flagged
+    assert '_needs_type_annotation' in result

--- a/tests/test_rust_scaffold.py
+++ b/tests/test_rust_scaffold.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from refactor.rules.rust_scaffold import (
+    generate_implementation_prompt,
+    scaffold_rust_project,
+    write_scaffold,
+)
+
+
+# ---------------------------------------------------------------------------
+# generate_implementation_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_implementation_prompt_has_type_reference():
+    source = "def add(a: int, b: int) -> int:\n    return a + b"
+    result = generate_implementation_prompt(source, "math_utils")
+    assert "Type Reference" in result
+    assert "i64" in result
+
+
+def test_implementation_prompt_has_python_source():
+    source = "def add(a: int, b: int) -> int:\n    return a + b"
+    result = generate_implementation_prompt(source, "math_utils")
+    assert "Original Python" in result
+    assert "return a + b" in result
+
+
+def test_implementation_prompt_has_rust_skeleton():
+    source = "def add(a: int, b: int) -> int:\n    return a + b"
+    result = generate_implementation_prompt(source, "math_utils")
+    assert "#[pyfunction]" in result
+    assert "fn add" in result
+
+
+def test_implementation_prompt_flags_dynamic():
+    source = "def fetch(url: str, **kwargs) -> str:\n    return getattr(obj, url)"
+    result = generate_implementation_prompt(source, "fetcher")
+    assert "kwargs" in result.lower() or "dynamic" in result.lower()
+
+
+def test_implementation_prompt_module_name_in_header():
+    source = "def noop() -> None:\n    pass"
+    result = generate_implementation_prompt(source, "my_module")
+    assert "my_module" in result
+
+
+def test_implementation_prompt_includes_class():
+    source = textwrap.dedent("""\
+        class Box:
+            def __init__(self, value: int) -> None:
+                self.value = value
+            def get(self) -> int:
+                return self.value
+    """)
+    result = generate_implementation_prompt(source, "containers")
+    assert "struct Box" in result
+    assert "Classes to Implement" in result
+
+
+def test_implementation_prompt_edge_cases_section():
+    source = "def add(a: int, b: int) -> int:\n    return a + b"
+    result = generate_implementation_prompt(source, "math_utils")
+    assert "Edge Cases" in result
+
+
+def test_implementation_prompt_no_unsafe():
+    source = "def add(a: int, b: int) -> int:\n    return a + b"
+    result = generate_implementation_prompt(source, "math_utils")
+    assert "unsafe" in result  # warns that none are needed
+
+
+def test_implementation_prompt_varargs_flagged():
+    source = "def variadic(*args: int) -> int:\n    return sum(args)"
+    result = generate_implementation_prompt(source, "varmod")
+    # vararg detected as dynamic pattern
+    assert "args" in result
+
+
+# ---------------------------------------------------------------------------
+# scaffold_rust_project
+# ---------------------------------------------------------------------------
+
+
+def test_scaffold_has_all_files():
+    source = textwrap.dedent("""\
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+
+        class Counter:
+            def __init__(self, start: int = 0):
+                self.count = start
+            def increment(self) -> int:
+                self.count += 1
+                return self.count
+    """)
+    result = scaffold_rust_project(source, "mymod")
+    assert "src/lib.rs" in result
+    assert "Cargo.toml" in result
+    assert "IMPLEMENTATION_GUIDE.md" in result
+
+    # Verify content
+    assert "use pyo3::prelude::*;" in result["src/lib.rs"]
+    assert 'name = "mymod"' in result["Cargo.toml"]
+    assert "fn greet" in result["src/lib.rs"]
+
+
+def test_scaffold_lib_rs_valid():
+    source = "def compute(x: float, y: float) -> float:\n    return x * y"
+    result = scaffold_rust_project(source, "compute_mod")
+    lib_rs = result["src/lib.rs"]
+    assert "#[pymodule]" in lib_rs
+    assert "fn compute_mod" in lib_rs
+
+
+def test_scaffold_cargo_toml_valid():
+    source = "def noop() -> None:\n    pass"
+    result = scaffold_rust_project(source, "test_mod")
+    cargo = result["Cargo.toml"]
+    assert "pyo3" in cargo
+    assert "cdylib" in cargo
+
+
+def test_scaffold_readme_present():
+    source = "def noop() -> None:\n    pass"
+    result = scaffold_rust_project(source, "mymod")
+    assert "README.md" in result
+    assert "mymod" in result["README.md"]
+
+
+def test_scaffold_python_wrapper_present():
+    source = "def noop() -> None:\n    pass"
+    result = scaffold_rust_project(source, "mymod")
+    assert "python_wrapper.py" in result
+
+
+def test_scaffold_implementation_guide_content():
+    source = "def add(a: int, b: int) -> int:\n    return a + b"
+    result = scaffold_rust_project(source, "addmod")
+    guide = result["IMPLEMENTATION_GUIDE.md"]
+    assert "Type Reference" in guide
+    assert "fn add" in guide
+
+
+def test_scaffold_class_in_lib_rs():
+    source = textwrap.dedent("""\
+        class Point:
+            def __init__(self, x: float, y: float) -> None:
+                self.x = x
+                self.y = y
+    """)
+    result = scaffold_rust_project(source, "geometry")
+    lib_rs = result["src/lib.rs"]
+    assert "struct Point" in lib_rs
+    assert "#[pyclass]" in lib_rs
+
+
+def test_scaffold_returns_dict_of_strings():
+    source = "def noop() -> None:\n    pass"
+    result = scaffold_rust_project(source, "check")
+    for key, value in result.items():
+        assert isinstance(key, str)
+        assert isinstance(value, str)
+
+
+# ---------------------------------------------------------------------------
+# write_scaffold
+# ---------------------------------------------------------------------------
+
+
+def test_write_scaffold_creates_files(tmp_path):
+    source = "def add(a: int, b: int) -> int:\n    return a + b"
+    scaffold = scaffold_rust_project(source, "mymod")
+    write_scaffold(scaffold, str(tmp_path))
+
+    for rel_path in scaffold:
+        full_path = tmp_path / rel_path
+        assert full_path.exists(), f"Expected {rel_path} to exist"
+        assert full_path.read_text() == scaffold[rel_path]
+
+
+def test_write_scaffold_creates_src_dir(tmp_path):
+    source = "def noop() -> None:\n    pass"
+    scaffold = scaffold_rust_project(source, "mymod")
+    write_scaffold(scaffold, str(tmp_path))
+    assert (tmp_path / "src").is_dir()
+    assert (tmp_path / "src" / "lib.rs").exists()


### PR DESCRIPTION
Tier 1 - AST rules to prepare Python for Rust conversion:
- FlagDynamicPatterns: mark getattr/eval/exec/**kwargs as Rust-incompatible
- InferTypeAnnotations: add types from defaults (x=0 → x: int = 0)
- EnsureAnnotationCompleteness: flag incompletely typed functions

Tier 2 - PyO3 Rust code generators:
- python_type_to_rust(): full type mapping with nested generics
- generate_pyfunction/pyclass/module(): #[pyfunction]/#[pyclass] stubs
- generate_cargo_toml(): minimal PyO3 crate config

Tier 3 - Orchestration:
- analyze_module(): readiness score, type coverage, dynamic pattern count
- generate_python_wrapper(): try/except import with pure Python fallback
- generate_implementation_prompt(): markdown guide for Claude agent
- scaffold_rust_project(): complete project in one call

101 tests, all passing.