### PR TITLE
Add Cython augmented pure Python annotation rules

### DIFF
--- a/refactor/rules/cython_augmented.py
+++ b/refactor/rules/cython_augmented.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from typing import Iterator
+
+from refactor import Rule
+from refactor.actions import InsertAfter, Replace
+
+__all__ = [
+    "ConvertTypeToCython",
+    "ConvertFunctionAnnotations",
+    "AddCythonMarkerDecorator",
+    "DeclareClassAttributes",
+    "AddCythonImport",
+    "ALL_RULES",
+]
+
+# Mapping from Python built-in type names to cython attribute names
+_TYPE_MAP: dict[str, str] = {
+    "int": "int",
+    "float": "double",
+    "complex": "doublecomplex",
+    "bool": "bint",
+}
+
+_SUPPORTED_MARKERS = frozenset({"cfunc", "ccall", "cclass", "nogil", "inline"})
+
+
+def _make_cython_attr(attr: str) -> ast.Attribute:
+    """Return an ast.Attribute node for ``cython.<attr>``."""
+    return ast.Attribute(
+        value=ast.Name(id="cython", ctx=ast.Load()),
+        attr=attr,
+        ctx=ast.Load(),
+    )
+
+
+def _is_bare_type_name(node: ast.expr) -> bool:
+    """Return True if *node* is a simple Name whose id is in _TYPE_MAP."""
+    return isinstance(node, ast.Name) and node.id in _TYPE_MAP
+
+
+def _is_already_cython(node: ast.expr) -> bool:
+    """Return True if *node* is already a ``cython.<something>`` attribute."""
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "cython"
+    )
+
+
+def _has_cython_decorator(func_node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return True if the function already has any cython.* decorator."""
+    for dec in func_node.decorator_list:
+        if _is_already_cython(dec):
+            return True
+        if (
+            isinstance(dec, ast.Call)
+            and isinstance(dec.func, ast.Attribute)
+            and isinstance(dec.func.value, ast.Name)
+            and dec.func.value.id == "cython"
+        ):
+            return True
+    return False
+
+
+def _inside_cython_compiled_guard(node: ast.AST, source: str) -> bool:
+    """Heuristic: check if node is inside an ``if not cython.compiled:`` block.
+
+    We do this by checking the source text of the lines around the node.
+    A full ancestry walk would be more robust but is heavier; this simple
+    heuristic covers the common case.
+    """
+    # We can't easily check ancestry here without the context providers,
+    # so we rely on the source lines instead.
+    lines = source.splitlines()
+    lineno = getattr(node, "lineno", None)
+    if lineno is None:
+        return False
+    # Walk backwards from the node's line looking for the guard
+    for i in range(lineno - 2, -1, -1):
+        stripped = lines[i].strip()
+        if stripped.startswith("if not cython.compiled") or stripped.startswith(
+            "if not cython.compiled:"
+        ):
+            return True
+        # Stop at blank lines or top-level defs/classes to avoid false positives
+        if stripped == "" and i < lineno - 10:
+            break
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: ConvertTypeToCython
+# ---------------------------------------------------------------------------
+
+
+class ConvertTypeToCython(Rule):
+    """Convert bare Python type annotations in variable declarations to
+    their cython equivalents (e.g. ``x: int = 0`` → ``x: cython.int = 0``).
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.AnnAssign)
+        assert _is_bare_type_name(node.annotation)
+        assert not _is_already_cython(node.annotation)
+        assert not _inside_cython_compiled_guard(node, self.context.source)
+
+        cython_attr = _TYPE_MAP[node.annotation.id]  # type: ignore[union-attr]
+        new_node = deepcopy(node)
+        new_node.annotation = _make_cython_attr(cython_attr)
+        return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: ConvertFunctionAnnotations
+# ---------------------------------------------------------------------------
+
+
+class ConvertFunctionAnnotations(Rule):
+    """Convert function parameter and return type annotations that use plain
+    Python types to cython equivalents, and add ``@cython.ccall`` /
+    ``@cython.returns(...)`` decorators as appropriate.
+    """
+
+    def match(
+        self, node: ast.AST
+    ) -> Replace | None:
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        assert not _inside_cython_compiled_guard(node, self.context.source)
+
+        args = node.args
+
+        # Collect parameter annotations that need conversion (skip self/cls and */**args)
+        params_to_convert: list[ast.arg] = []
+        for arg in args.args + args.posonlyargs + args.kwonlyargs:
+            if arg.arg in ("self", "cls"):
+                continue
+            if arg.annotation is not None and _is_bare_type_name(arg.annotation):
+                params_to_convert.append(arg)
+
+        # Check return annotation
+        return_convertible = (
+            node.returns is not None and _is_bare_type_name(node.returns)
+        )
+
+        # Only proceed if there is something to convert
+        assert params_to_convert or return_convertible
+
+        # Don't add @cython.ccall if function already has a cython decorator
+        add_ccall = not _has_cython_decorator(node)
+
+        new_node = deepcopy(node)
+
+        # Replace parameter annotations
+        def _patch_args(arg_list: list[ast.arg]) -> None:
+            for arg in arg_list:
+                if arg.arg in ("self", "cls"):
+                    continue
+                if arg.annotation is not None and _is_bare_type_name(arg.annotation):
+                    arg.annotation = _make_cython_attr(_TYPE_MAP[arg.annotation.id])
+
+        _patch_args(new_node.args.args)
+        _patch_args(new_node.args.posonlyargs)
+        _patch_args(new_node.args.kwonlyargs)
+
+        # Replace return annotation
+        if return_convertible:
+            cython_return_attr = _TYPE_MAP[new_node.returns.id]  # type: ignore[union-attr]
+            new_node.returns = _make_cython_attr(cython_return_attr)
+
+        # Build new decorator list
+        new_decorators: list[ast.expr] = []
+
+        if add_ccall:
+            new_decorators.append(_make_cython_attr("ccall"))
+
+        if return_convertible:
+            cython_return_attr = _TYPE_MAP[node.returns.id]  # type: ignore[union-attr]
+            new_decorators.append(
+                ast.Call(
+                    func=_make_cython_attr("returns"),
+                    args=[_make_cython_attr(cython_return_attr)],
+                    keywords=[],
+                )
+            )
+
+        new_node.decorator_list = new_decorators + list(new_node.decorator_list)
+
+        return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: AddCythonMarkerDecorator
+# ---------------------------------------------------------------------------
+
+
+class AddCythonMarkerDecorator(Rule):
+    """Convert ``# cython: <marker>`` comments immediately preceding a
+    function, async function, or class definition into ``@cython.<marker>``
+    decorators.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+
+        lines = self.context.source.splitlines()
+
+        # The node's lineno is 1-based; account for decorator_list shifting
+        # the actual def/class keyword line.
+        if node.decorator_list:
+            def_lineno = node.decorator_list[0].lineno
+        else:
+            def_lineno = node.lineno
+
+        # The line immediately before the first decorator / def keyword
+        preceding_lineno = def_lineno - 2  # 0-based index
+        assert preceding_lineno >= 0
+
+        preceding_line = lines[preceding_lineno].strip()
+        assert preceding_line.startswith("# cython:")
+
+        marker_value = preceding_line[len("# cython:"):].strip()
+        assert marker_value in _SUPPORTED_MARKERS
+
+        # Idempotency guard: if the first existing decorator is already
+        # cython.<marker_value>, don't add it again.
+        if node.decorator_list:
+            first = node.decorator_list[0]
+            if (
+                isinstance(first, ast.Attribute)
+                and isinstance(first.value, ast.Name)
+                and first.value.id == "cython"
+                and first.attr == marker_value
+            ):
+                return None
+
+        new_node = deepcopy(node)
+        new_node.decorator_list = [_make_cython_attr(marker_value)] + list(
+            new_node.decorator_list
+        )
+        return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: AddCythonImport
+# ---------------------------------------------------------------------------
+
+
+class AddCythonImport(Rule):
+    """If the module uses any ``cython.*`` references but doesn't yet
+    ``import cython``, insert ``import cython`` after the last existing
+    import statement.
+
+    Strategy: match on each top-level import statement and fire only on the
+    *last* one, so we have a node with source positions (ast.Module itself
+    is skipped by the Session's fixed-point walker because it has no line
+    number attributes).
+    """
+
+    def match(self, node: ast.AST) -> InsertAfter | None:
+        assert isinstance(node, (ast.Import, ast.ImportFrom))
+
+        tree = self.context.tree
+
+        # Check whether ``import cython`` already exists — if so, nothing to do.
+        for stmt in ast.walk(tree):
+            if isinstance(stmt, ast.Import):
+                for alias in stmt.names:
+                    if alias.name == "cython" and alias.asname is None:
+                        return None
+            if isinstance(stmt, ast.ImportFrom):
+                if stmt.module == "cython":
+                    return None
+
+        # Check whether any cython.* attribute is used anywhere in the tree.
+        has_cython_usage = any(
+            isinstance(n, ast.Attribute)
+            and isinstance(n.value, ast.Name)
+            and n.value.id == "cython"
+            for n in ast.walk(tree)
+        )
+        assert has_cython_usage
+
+        # Only fire on the *last* top-level import statement so we insert
+        # ``import cython`` exactly once, right after all existing imports.
+        last_import: ast.stmt | None = None
+        for stmt in tree.body:
+            if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+                last_import = stmt
+
+        assert last_import is node, "Not the last import statement"
+
+        import_node = ast.Import(names=[ast.alias(name="cython")])
+        return InsertAfter(node, import_node)
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: DeclareClassAttributes
+# ---------------------------------------------------------------------------
+
+
+def _has_cclass_decorator(class_node: ast.ClassDef) -> bool:
+    """Return True if the class has a ``@cython.cclass`` decorator."""
+    for dec in class_node.decorator_list:
+        if (
+            isinstance(dec, ast.Attribute)
+            and isinstance(dec.value, ast.Name)
+            and dec.value.id == "cython"
+            and dec.attr == "cclass"
+        ):
+            return True
+    return False
+
+
+def _has_existing_declare(class_node: ast.ClassDef) -> bool:
+    """Return True if any class-level statement is a ``cython.declare(...)`` call."""
+    for stmt in class_node.body:
+        # Look for: attr = cython.declare(...)
+        if isinstance(stmt, ast.Assign):
+            if (
+                isinstance(stmt.value, ast.Call)
+                and isinstance(stmt.value.func, ast.Attribute)
+                and isinstance(stmt.value.func.value, ast.Name)
+                and stmt.value.func.value.id == "cython"
+                and stmt.value.func.attr == "declare"
+            ):
+                return True
+    return False
+
+
+def _find_init_method(
+    class_node: ast.ClassDef,
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Return the ``__init__`` method of a class, or None."""
+    for stmt in class_node.body:
+        if (
+            isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and stmt.name == "__init__"
+        ):
+            return stmt
+    return None
+
+
+def _param_type_map(
+    init_node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> dict[str, str]:
+    """Build a mapping from param name → cython type string for typed params."""
+    result: dict[str, str] = {}
+    for arg in init_node.args.args + init_node.args.posonlyargs + init_node.args.kwonlyargs:
+        if arg.arg in ("self", "cls"):
+            continue
+        if arg.annotation is not None and _is_bare_type_name(arg.annotation):
+            result[arg.arg] = _TYPE_MAP[arg.annotation.id]  # type: ignore[union-attr]
+    return result
+
+
+def _collect_self_assignments(
+    init_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    param_types: dict[str, str],
+) -> list[tuple[str, str]]:
+    """Return list of (attr_name, cython_type) for ``self.x = param`` assignments
+    where *param* has a known type from *param_types*.
+    """
+    seen: dict[str, str] = {}
+    for stmt in ast.walk(init_node):
+        if not isinstance(stmt, ast.Assign):
+            continue
+        if len(stmt.targets) != 1:
+            continue
+        target = stmt.targets[0]
+        if not (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        ):
+            continue
+        attr_name = target.attr
+        # The RHS must be a simple Name that maps to a typed param
+        if isinstance(stmt.value, ast.Name) and stmt.value.id in param_types:
+            if attr_name not in seen:
+                seen[attr_name] = param_types[stmt.value.id]
+    return list(seen.items())
+
+
+def _make_declare_assign(attr_name: str, cython_type: str) -> ast.Assign:
+    """Return ``attr_name = cython.declare(cython.<cython_type>)``."""
+    return ast.Assign(
+        targets=[ast.Name(id=attr_name, ctx=ast.Store())],
+        value=ast.Call(
+            func=_make_cython_attr("declare"),
+            args=[_make_cython_attr(cython_type)],
+            keywords=[],
+        ),
+        lineno=0,
+        col_offset=0,
+    )
+
+
+class DeclareClassAttributes(Rule):
+    """For classes decorated with ``@cython.cclass``, scan ``__init__`` for
+    ``self.attr = param`` assignments where *param* has a type annotation, and
+    insert class-level ``attr = cython.declare(cython.type)`` declarations
+    before ``__init__``.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ClassDef)
+        assert _has_cclass_decorator(node)
+        assert not _has_existing_declare(node)
+
+        init_node = _find_init_method(node)
+        assert init_node is not None
+
+        param_types = _param_type_map(init_node)
+        assert param_types  # must have at least one typed param
+
+        assignments = _collect_self_assignments(init_node, param_types)
+        assert assignments  # must have at least one self.attr = typed_param
+
+        new_node = deepcopy(node)
+
+        # Build declare statements to insert before __init__
+        declare_stmts: list[ast.stmt] = [
+            _make_declare_assign(attr_name, cython_type)
+            for attr_name, cython_type in assignments
+        ]
+
+        # Find the index of __init__ in the new class body and insert before it
+        new_body: list[ast.stmt] = []
+        for stmt in new_node.body:
+            if (
+                isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and stmt.name == "__init__"
+            ):
+                new_body.extend(declare_stmts)
+            new_body.append(stmt)
+
+        new_node.body = new_body
+        return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# All rules — ordered for correct fixed-point application
+# ---------------------------------------------------------------------------
+
+ALL_RULES = [
+    ConvertTypeToCython,
+    ConvertFunctionAnnotations,
+    AddCythonMarkerDecorator,
+    DeclareClassAttributes,
+    AddCythonImport,
+]
+
+if __name__ == "__main__":
+    import refactor
+
+    refactor.run(ALL_RULES)

--- a/tests/test_cython_augmented.py
+++ b/tests/test_cython_augmented.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from refactor import Session
+from refactor.rules.cython_augmented import (
+    ALL_RULES,
+    AddCythonImport,
+    AddCythonMarkerDecorator,
+    ConvertFunctionAnnotations,
+    ConvertTypeToCython,
+    DeclareClassAttributes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def run(rule_cls, source: str) -> str:
+    return Session([rule_cls]).run(textwrap.dedent(source))
+
+
+def unchanged(rule_cls, source: str) -> None:
+    dedented = textwrap.dedent(source)
+    assert Session([rule_cls]).run(dedented) == dedented
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: ConvertTypeToCython
+# ---------------------------------------------------------------------------
+
+
+def test_convert_int_annotation():
+    source = """\
+        x: int = 0
+    """
+    result = run(ConvertTypeToCython, source)
+    assert "x: cython.int = 0" in result
+
+
+def test_convert_float_annotation():
+    source = """\
+        y: float = 1.0
+    """
+    result = run(ConvertTypeToCython, source)
+    assert "y: cython.double = 1.0" in result
+
+
+def test_convert_bool_annotation():
+    source = """\
+        flag: bool = True
+    """
+    result = run(ConvertTypeToCython, source)
+    assert "flag: cython.bint = True" in result
+
+
+def test_convert_complex_annotation():
+    source = """\
+        z: complex = 1+2j
+    """
+    result = run(ConvertTypeToCython, source)
+    assert "z: cython.doublecomplex = " in result
+
+
+def test_skip_complex_annotations():
+    """Subscript types like list[int] should not be converted."""
+    unchanged(
+        ConvertTypeToCython,
+        """\
+        items: list[int] = []
+        """,
+    )
+
+
+def test_skip_already_cython():
+    """Already-cython annotations must not be double-converted."""
+    unchanged(
+        ConvertTypeToCython,
+        """\
+        x: cython.int = 0
+        """,
+    )
+
+
+def test_skip_optional_annotation():
+    """Optional[int] is not a bare Name — skip."""
+    unchanged(
+        ConvertTypeToCython,
+        """\
+        from typing import Optional
+        x: Optional[int] = None
+        """,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: ConvertFunctionAnnotations
+# ---------------------------------------------------------------------------
+
+
+def test_convert_function_params():
+    source = """\
+        def add(x: int, y: int) -> int:
+            return x + y
+    """
+    result = run(ConvertFunctionAnnotations, source)
+    assert "x: cython.int" in result
+    assert "y: cython.int" in result
+
+
+def test_convert_function_return():
+    source = """\
+        def scale(x: float) -> float:
+            return x * 2.0
+    """
+    result = run(ConvertFunctionAnnotations, source)
+    assert "@cython.returns(cython.double)" in result
+    assert "@cython.ccall" in result
+
+
+def test_skip_self_annotation():
+    """The ``self`` parameter must not be annotated."""
+    source = """\
+        class Foo:
+            def method(self, x: int) -> int:
+                return x
+    """
+    result = run(ConvertFunctionAnnotations, source)
+    # self should not get a cython annotation
+    assert "self: cython" not in result
+    # but x should be converted
+    assert "x: cython.int" in result
+
+
+def test_skip_function_no_convertible_annotations():
+    """A function with no convertible annotations stays unchanged."""
+    unchanged(
+        ConvertFunctionAnnotations,
+        """\
+        def process(items: list) -> None:
+            pass
+        """,
+    )
+
+
+def test_no_double_ccall():
+    """A function that already has a cython decorator should not get another @cython.ccall."""
+    source = """\
+        import cython
+
+        @cython.cfunc
+        def fast(x: int) -> int:
+            return x
+    """
+    result = run(ConvertFunctionAnnotations, source)
+    assert result.count("@cython.ccall") == 0
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: AddCythonMarkerDecorator
+# ---------------------------------------------------------------------------
+
+
+def test_marker_cfunc():
+    source = """\
+        # cython: cfunc
+        def internal_helper(x: int) -> int:
+            return x * 2
+    """
+    result = run(AddCythonMarkerDecorator, source)
+    assert "@cython.cfunc" in result
+
+
+def test_marker_cclass():
+    source = """\
+        # cython: cclass
+        class FastProcessor:
+            pass
+    """
+    result = run(AddCythonMarkerDecorator, source)
+    assert "@cython.cclass" in result
+
+
+def test_marker_ccall():
+    source = """\
+        # cython: ccall
+        def helper():
+            pass
+    """
+    result = run(AddCythonMarkerDecorator, source)
+    assert "@cython.ccall" in result
+
+
+def test_marker_not_applied_without_comment():
+    """Functions without a cython marker comment must not get a decorator."""
+    unchanged(
+        AddCythonMarkerDecorator,
+        """\
+        def regular_function():
+            pass
+        """,
+    )
+
+
+def test_marker_unsupported_value():
+    """An unsupported marker value must leave the node unchanged."""
+    unchanged(
+        AddCythonMarkerDecorator,
+        """\
+        # cython: unknown_marker
+        def helper():
+            pass
+        """,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: AddCythonImport
+# ---------------------------------------------------------------------------
+
+
+def test_add_cython_import():
+    source = """\
+        import os
+
+        x: cython.int = 0
+    """
+    result = run(AddCythonImport, source)
+    assert "import cython" in result
+
+
+def test_no_import_when_no_cython():
+    """No ``import cython`` should be added when there is no cython usage."""
+    unchanged(
+        AddCythonImport,
+        """\
+        import os
+
+        x: int = 0
+        """,
+    )
+
+
+def test_no_duplicate_import():
+    """If ``import cython`` already exists, it must not be added again."""
+    unchanged(
+        AddCythonImport,
+        """\
+        import cython
+        import os
+
+        x: cython.int = 0
+        """,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Full conversion integration test
+# ---------------------------------------------------------------------------
+
+
+def test_full_conversion():
+    """Realistic before/after transformation using all rules in sequence."""
+    source = textwrap.dedent("""\
+        import os
+
+        counter: int = 0
+        ratio: float = 0.0
+
+        # cython: cfunc
+        def compute(x: int, y: float) -> float:
+            return x * y
+    """)
+
+    # Apply rules in sequence: type annotations first, then function annotations,
+    # then marker decorators, then import.
+    result = source
+    for rule_cls in [
+        ConvertTypeToCython,
+        ConvertFunctionAnnotations,
+        AddCythonMarkerDecorator,
+        AddCythonImport,
+    ]:
+        result = Session([rule_cls]).run(result)
+
+    assert "counter: cython.int = 0" in result
+    assert "ratio: cython.double = 0.0" in result
+    assert "@cython.cfunc" in result
+    assert "x: cython.int" in result
+    assert "y: cython.double" in result
+    assert "@cython.returns(cython.double)" in result
+    assert "import cython" in result
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: DeclareClassAttributes
+# ---------------------------------------------------------------------------
+
+
+def test_declare_class_attributes():
+    """Basic case: @cython.cclass with typed __init__ params → class-level declares."""
+    source = """\
+        import cython
+
+        @cython.cclass
+        class Point:
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+    """
+    result = run(DeclareClassAttributes, source)
+    assert "x = cython.declare(cython.int)" in result
+    assert "y = cython.declare(cython.int)" in result
+
+
+def test_skip_non_cclass():
+    """A class without @cython.cclass must not be modified."""
+    unchanged(
+        DeclareClassAttributes,
+        """\
+        class Point:
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+        """,
+    )
+
+
+def test_skip_existing_declarations():
+    """If cython.declare already exists in the class body, don't add more."""
+    unchanged(
+        DeclareClassAttributes,
+        """\
+        import cython
+
+        @cython.cclass
+        class Point:
+            x = cython.declare(cython.int)
+            y = cython.declare(cython.int)
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+        """,
+    )
+
+
+def test_declare_mixed_types():
+    """Class with int, float, and bool typed params → correct cython types."""
+    source = """\
+        import cython
+
+        @cython.cclass
+        class Stats:
+            def __init__(self, count: int, ratio: float, active: bool):
+                self.count = count
+                self.ratio = ratio
+                self.active = active
+    """
+    result = run(DeclareClassAttributes, source)
+    assert "count = cython.declare(cython.int)" in result
+    assert "ratio = cython.declare(cython.double)" in result
+    assert "active = cython.declare(cython.bint)" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration: ALL_RULES
+# ---------------------------------------------------------------------------
+
+
+def test_all_rules_list():
+    """ALL_RULES must be a non-empty list of Rule subclasses."""
+    from refactor import Rule
+
+    assert isinstance(ALL_RULES, list)
+    assert len(ALL_RULES) > 0
+    for rule_cls in ALL_RULES:
+        assert issubclass(rule_cls, Rule)
+
+
+def test_full_module_conversion():
+    """Full module with all patterns: types, functions, markers, classes."""
+    source = textwrap.dedent("""\
+        import os
+
+        counter: int = 0
+        ratio: float = 0.5
+
+        # cython: cfunc
+        def _internal(x: int) -> int:
+            return x * 2
+
+        def public_api(x: int, y: float) -> float:
+            return _internal(x) * y
+
+        # cython: cclass
+        class Accumulator:
+            def __init__(self, start: int, factor: float):
+                self.total = start
+                self.factor = factor
+
+            def add(self, value: int) -> float:
+                self.total = self.total + value
+                return self.total * self.factor
+    """)
+    session = Session(ALL_RULES)
+    result = session.run(source)
+
+    # Verify import added
+    assert "import cython" in result
+
+    # Verify type conversions on module-level variables
+    assert "counter: cython.int = 0" in result
+    assert "ratio: cython.double = 0.5" in result
+
+    # Verify marker decorators applied
+    assert "@cython.cfunc" in result
+    assert "@cython.cclass" in result
+
+    # Verify class attributes declared
+    assert "cython.declare(" in result
+
+    # Verify function annotations converted
+    assert "cython.int" in result
+    assert "cython.double" in result


### PR DESCRIPTION
5 AST rules for mechanical Python → Cython annotation:
- ConvertTypeToCython: int→cython.int, float→cython.double, bool→cython.bint
- ConvertFunctionAnnotations: add @cython.ccall, @cython.returns(), param types
- AddCythonMarkerDecorator: # cython: cfunc comment → @cython.cfunc decorator
- DeclareClassAttributes: @cython.cclass classes get cython.declare() from __init__
- AddCythonImport: add import cython when annotations present

27 tests, all passing. Runnable via:
  python -m refactor -d refactor/rules/cython_augmented.py module.py