### PR TITLE
chore: Add auto-sync workflow for applications branch

### DIFF
--- a/.github/workflows/sync-applications.yml
+++ b/.github/workflows/sync-applications.yml
@@ -1,0 +1,32 @@
+name: Sync Applications
+
+on:
+  push:
+    branches: [development]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: "Merge development → applications"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout applications branch
+        uses: actions/checkout@v4
+        with:
+          ref: applications
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge development into applications
+        run: |
+          git fetch origin development
+          git merge origin/development --no-edit -m "chore: auto-sync from development"
+
+      - name: Push updated applications
+        run: git push origin applications


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync-applications.yml`
- Automatically merges `development` → `applications` on every push to `development`
- Triggered after PR merges to development
- Uses `github-actions[bot]` for automated commits
- `refactor/rules/` doesn't exist upstream, so merges are always conflict-free

## How it works
```
PR merged → development updated → workflow triggers → merge development into applications → push
```

## Test plan
- [ ] Merge this PR and PR #6 to development
- [ ] Verify sync workflow triggers and updates applications branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)