### PR TITLE
fix: Add security-events:write permission for CodeQL upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       pull-requests: write
       actions: read
       checks: write
+      security-events: write
     with:
       pixi-environment: "ci"
       python-versions: '["3.10", "3.11", "3.12", "3.14"]'


### PR DESCRIPTION
## Summary
- Add `security-events: write` to ci workflow permissions
- Fixes: `Resource not accessible by integration` error during CodeQL result upload

Co-Authored-By: MementoRC (https://github.com/MementoRC)