### PR TITLE
chore: Add applications branch to CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, development]
+    branches: [main, development, applications]
   pull_request:
-    branches: [main, development]
+    branches: [main, development, applications]
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary
- Add `applications` to CI push and pull_request triggers
- Enables CI quality gates for PRs targeting applications branch
- Branch policy already blocks applications → main/development

Co-Authored-By: MementoRC (https://github.com/MementoRC)