### PR TITLE
chore: Add dependabot for GitHub Actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "development"


### PR DESCRIPTION
Adds `.github/dependabot.yml` targeting `development` branch.
Auto-creates PRs when GitHub Actions versions update (checkout, setup-pixi, etc.).

Co-Authored-By: MementoRC (https://github.com/MementoRC)