### PR TITLE
fix: Remove --admin from sync merge (GITHUB_TOKEN lacks admin)

### DIFF
--- a/.github/workflows/sync-applications.yml
+++ b/.github/workflows/sync-applications.yml
@@ -49,5 +49,5 @@ jobs:
           fi
           # Merge the PR
           if [ -n "$EXISTING_PR" ]; then
-            gh pr merge "$EXISTING_PR" --merge --admin
+            gh pr merge "$EXISTING_PR" --merge --delete-branch || echo "Merge failed, PR may need manual merge"
           fi


### PR DESCRIPTION
- `--admin` flag requires admin privileges that GITHUB_TOKEN doesn't have
- Changed to `--merge --delete-branch` with graceful failure handling
- Closed stale PR #16 which had conflicts

Co-Authored-By: MementoRC (https://github.com/MementoRC)