### PR TITLE
fix: Address pytest migration issues #25, #26, #27

### DIFF
--- a/refactor/rules/pytest_migration.py
+++ b/refactor/rules/pytest_migration.py
@@ -387,10 +387,14 @@ class ConvertSetUpTearDown(Rule):
     _TEARDOWN_NAMES = frozenset({"tearDown", "asyncTearDown"})
 
     def match(self, node: ast.AST) -> Replace | Erase | None:
-        # --- Handle super().setUp() removal ---
+        # --- Handle super().setUp() / super().tearDown() / await super().asyncSetUp() etc. ---
         if isinstance(node, ast.Expr):
-            assert isinstance(node.value, ast.Call)
-            call = node.value
+            inner_value = node.value
+            # Unwrap await if present: `await super().asyncSetUp()`
+            if isinstance(inner_value, ast.Await):
+                inner_value = inner_value.value
+            assert isinstance(inner_value, ast.Call)
+            call = inner_value
             assert isinstance(call.func, ast.Attribute)
             assert call.func.attr in ("setUp", "asyncSetUp", "tearDown", "asyncTearDown")
             assert isinstance(call.func.value, ast.Call)
@@ -490,6 +494,31 @@ class ConvertAssertRaises(Rule):
         new_node = clone(node)
         new_node.items = new_items
         ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# ConvertExceptionToValue
+# ---------------------------------------------------------------------------
+
+
+class ConvertExceptionToValue(Rule):
+    """Convert cm.exception -> cm.value after pytest.raises context managers.
+
+    When assertRaises is converted to pytest.raises, the captured exception
+    is accessed via .value (not .exception).
+
+    Example:
+        cm.exception   ->   cm.value
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.Attribute)
+        assert node.attr == "exception"
+        assert isinstance(node.value, ast.Name)
+
+        new_node = clone(node)
+        new_node.attr = "value"
         return Replace(node, new_node)
 
 
@@ -671,6 +700,7 @@ ALL_RULES = [
     ConvertAssertions,
     ConvertSetUpTearDown,
     ConvertAssertRaises,
+    ConvertExceptionToValue,
     ConvertUnittestDecorators,
     AddPytestImport,  # Must be last: adds import pytest after all pytest refs are created
 ]

--- a/tests/test_pytest_migration.py
+++ b/tests/test_pytest_migration.py
@@ -8,6 +8,7 @@ from refactor.rules.pytest_migration import (
     AddPytestImport,
     ConvertAssertions,
     ConvertAssertRaises,
+    ConvertExceptionToValue,
     ConvertSetUpTearDown,
     ConvertUnittestDecorators,
     RemoveTestWrapperImport,
@@ -790,3 +791,55 @@ def test_no_mixin_init_override_for_pure_testcase():
 
     assert "class TestFoo:" in result
     assert "__init__ = None" not in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #27: assertIsNone / assertIsNotNone operator tests
+# ---------------------------------------------------------------------------
+
+
+def test_assert_is_none_uses_is():
+    """assertIsNone(x) must produce 'assert x is None', not 'assert x == None'."""
+    result = _assert("self.assertIsNone(x)\n")
+    assert result == "assert x is None\n"
+
+
+def test_assert_is_not_none_uses_is_not():
+    """assertIsNotNone(x) must produce 'assert x is not None', not 'assert x != None'."""
+    result = _assert("self.assertIsNotNone(x)\n")
+    assert result == "assert x is not None\n"
+
+
+# ---------------------------------------------------------------------------
+# Issue #26: super().asyncSetUp() removal tests
+# ---------------------------------------------------------------------------
+
+
+def test_remove_super_async_setup():
+    """await super().asyncSetUp() must be removed by ConvertSetUpTearDown."""
+    source = """\
+        async def asyncSetUp(self):
+            await super().asyncSetUp()
+            self.foo = 1
+        """
+    result = _setup(source)
+    assert "super().asyncSetUp()" not in result
+    assert "self.foo = 1" in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #25: cm.exception -> cm.value tests
+# ---------------------------------------------------------------------------
+
+
+def test_convert_exception_to_value():
+    """cm.exception must be converted to cm.value."""
+    source = """\
+        with self.assertRaises(ValueError) as cm:
+            do_something()
+        assert cm.exception is not None
+        """
+    result = _run(ConvertAssertRaises, ConvertExceptionToValue, source=textwrap.dedent(source))
+    assert "cm.value" in result
+    assert "cm.exception" not in result
+    assert "pytest.raises(ValueError)" in result


### PR DESCRIPTION
## Summary

- **#25**: Add `ConvertExceptionToValue` rule — converts `cm.exception` to `cm.value` after assertRaises conversion
- **#26**: Handle `await super().asyncSetUp()` and `await super().asyncTearDown()` removal (was only removing sync `super().setUp()`)
- **#27**: Verified `assertIsNone`/`assertIsNotNone` already use `is`/`is not` correctly — added explicit tests

All gates verified locally: lint ✅, format ✅, tests ✅

Closes #25, closes #26, closes #27

Co-Authored-By: MementoRC (https://github.com/MementoRC)