### PR TITLE
fix: assertEqual(x, True/False/None) uses idiomatic assertions (#29)

### DIFF
--- a/refactor/rules/pytest_migration.py
+++ b/refactor/rules/pytest_migration.py
@@ -217,11 +217,24 @@ def _extract_msg(call: ast.Call, msg_index: int) -> ast.expr | None:
 # Map from assertion method name to a callable that takes the Call node and
 # returns the test expression for ast.Assert.
 def _conv_equal(call: ast.Call) -> ast.expr:
-    return ast.Compare(left=call.args[0], ops=[ast.Eq()], comparators=[call.args[1]])
+    comparator = call.args[1]
+    # Idiomatic forms for assertEqual(x, True/False/None)
+    if isinstance(comparator, ast.Constant):
+        if comparator.value is True:
+            return call.args[0]
+        if comparator.value is False:
+            return ast.UnaryOp(op=ast.Not(), operand=call.args[0])
+        if comparator.value is None:
+            return ast.Compare(left=call.args[0], ops=[ast.Is()], comparators=[comparator])
+    return ast.Compare(left=call.args[0], ops=[ast.Eq()], comparators=[comparator])
 
 
 def _conv_not_equal(call: ast.Call) -> ast.expr:
-    return ast.Compare(left=call.args[0], ops=[ast.NotEq()], comparators=[call.args[1]])
+    comparator = call.args[1]
+    # Idiomatic form for assertNotEqual(x, None)
+    if isinstance(comparator, ast.Constant) and comparator.value is None:
+        return ast.Compare(left=call.args[0], ops=[ast.IsNot()], comparators=[comparator])
+    return ast.Compare(left=call.args[0], ops=[ast.NotEq()], comparators=[comparator])
 
 
 def _conv_true(call: ast.Call) -> ast.expr:

--- a/tests/test_pytest_migration.py
+++ b/tests/test_pytest_migration.py
@@ -315,6 +315,26 @@ def test_convert_assert_equal():
     assert result == "assert a == b\n"
 
 
+def test_convert_assert_equal_true_idiomatic():
+    result = _assert("self.assertEqual(x, True)\n")
+    assert result == "assert x\n"
+
+
+def test_convert_assert_equal_false_idiomatic():
+    result = _assert("self.assertEqual(x, False)\n")
+    assert result == "assert not x\n"
+
+
+def test_convert_assert_equal_none_idiomatic():
+    result = _assert("self.assertEqual(x, None)\n")
+    assert result == "assert x is None\n"
+
+
+def test_convert_assert_not_equal_none_idiomatic():
+    result = _assert("self.assertNotEqual(x, None)\n")
+    assert result == "assert x is not None\n"
+
+
 def test_convert_assert_not_equal():
     result = _assert("self.assertNotEqual(a, b)\n")
     assert result == "assert a != b\n"


### PR DESCRIPTION
## Problem
`assertEqual(x, False)` → `assert x == False` (E712), `assertEqual(x, None)` → `assert x == None` (E711)

## Fix
Special-case `_conv_equal` and `_conv_not_equal` when comparator is `True`, `False`, or `None`:
- `assertEqual(x, True)` → `assert x`
- `assertEqual(x, False)` → `assert not x`
- `assertEqual(x, None)` → `assert x is None`
- `assertNotEqual(x, None)` → `assert x is not None`

4 new tests. All gates verified locally.

Closes #29

Co-Authored-By: MementoRC (https://github.com/MementoRC)