### PR TITLE
feat(py312): add Phase 1 modernization rule pack + refactor-py312 entrypoint

### DIFF
--- a/refactor/cli_py312.py
+++ b/refactor/cli_py312.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from itertools import chain
+from pathlib import Path
+
+from refactor.core import Session
+from refactor.rules.py312_migration import (
+    CORE_RULES,
+    IDIOMATIC_RULES,
+    OPTIN_RULE_GROUPS,
+)
+from refactor.runner import expand_paths, run_files
+
+
+def main() -> int:
+    parser = ArgumentParser(
+        prog="refactor-py312",
+        description=(
+            "AST-based Python 3.12 modernization rules. "
+            "Default invocation runs CORE_RULES (breaking-change fixes) plus IDIOMATIC_RULES "
+            "(non-breaking modernization). Higher-risk semantic transforms must be opted into "
+            "with --enable=<group>."
+        ),
+    )
+    parser.add_argument(
+        "src", nargs="+", type=Path, help="Source paths (files or directories) to transform."
+    )
+    parser.add_argument(
+        "-n",
+        "--dont-apply",
+        action="store_false",
+        default=True,
+        help="Show proposed changes without writing them.",
+    )
+    parser.add_argument(
+        "--enable",
+        action="append",
+        default=[],
+        metavar="GROUP",
+        help=(
+            "Enable an opt-in rule group. May be passed multiple times. "
+            "Available groups: " + ", ".join(sorted(OPTIN_RULE_GROUPS) | {"all"})
+            if OPTIN_RULE_GROUPS
+            else "Enable an opt-in rule group (no groups available in this build)."
+        ),
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of worker processes (default: 1).",
+    )
+
+    options = parser.parse_args()
+
+    rules = list(CORE_RULES) + list(IDIOMATIC_RULES)
+    for group in options.enable:
+        if group == "all":
+            for group_rules in OPTIN_RULE_GROUPS.values():
+                rules.extend(group_rules)
+        elif group in OPTIN_RULE_GROUPS:
+            rules.extend(OPTIN_RULE_GROUPS[group])
+        else:
+            parser.error(
+                f"unknown --enable group: {group!r}. "
+                f"Available: {sorted(OPTIN_RULE_GROUPS) + ['all']}"
+            )
+
+    session = Session(rules)
+    files = chain.from_iterable(expand_paths(source_dest) for source_dest in options.src)
+    return run_files(session, files, apply=options.dont_apply, workers=options.workers)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/refactor/rules/py312_migration/__init__.py
+++ b/refactor/rules/py312_migration/__init__.py
@@ -1,0 +1,75 @@
+"""Python 3.12 modernization rules for the `refactor-py312` CLI.
+
+This package is consumed by Hummingbot's `custom_git_setup/scripts/hummingbot-branch-tracking.sh`
+to modernize upstream/development sources to py3.12 idioms on every cron rebuild.
+
+Phase 1 rules (CORE_RULES) handle py3.12 breaking removals.
+Phase 2 rules (IDIOMATIC_RULES) handle non-breaking modernization (added in PR #2).
+Phase 3 rules (OPTIN_RULE_GROUPS) are high-risk/semantic-changing and opt-in only (added in PR #3).
+"""
+
+from __future__ import annotations
+
+from refactor.rules.py312_migration.asyncio_modern import AsyncioGetEventLoopRule
+from refactor.rules.py312_migration.datetime_modern import (
+    DatetimeUtcfromtimestampRule,
+    DatetimeUtcnowRule,
+)
+from refactor.rules.py312_migration.distutils import (
+    DistutilsCommandRule,
+    DistutilsCoreSetupRule,
+    DistutilsLogRule,
+    DistutilsSpawnRule,
+    DistutilsSysconfigRule,
+    DistutilsUtilStrtoboolRule,
+    DistutilsVersionRule,
+)
+from refactor.rules.py312_migration.inspect_modern import (
+    InspectFormatargspecRule,
+    InspectGetargspecRule,
+)
+from refactor.rules.py312_migration.stdlib_removed import RemovedStdlibImportRule
+
+CORE_RULES = [
+    # distutils removal (py3.12 removes distutils entirely)
+    DistutilsCoreSetupRule,
+    DistutilsCommandRule,
+    DistutilsVersionRule,
+    DistutilsSpawnRule,
+    DistutilsUtilStrtoboolRule,
+    DistutilsSysconfigRule,
+    DistutilsLogRule,
+    # PEP 594 stdlib removals
+    RemovedStdlibImportRule,
+    # datetime utcnow deprecation
+    DatetimeUtcnowRule,
+    DatetimeUtcfromtimestampRule,
+    # asyncio get_event_loop deprecation in async contexts
+    AsyncioGetEventLoopRule,
+    # inspect.getargspec removal
+    InspectGetargspecRule,
+    InspectFormatargspecRule,
+]
+
+IDIOMATIC_RULES: list = []  # Filled in Phase 2
+
+OPTIN_RULE_GROUPS: dict[str, list] = {}  # Filled in Phase 3
+
+__all__ = [
+    "AsyncioGetEventLoopRule",
+    "DatetimeUtcfromtimestampRule",
+    "DatetimeUtcnowRule",
+    "DistutilsCommandRule",
+    "DistutilsCoreSetupRule",
+    "DistutilsLogRule",
+    "DistutilsSpawnRule",
+    "DistutilsSysconfigRule",
+    "DistutilsUtilStrtoboolRule",
+    "DistutilsVersionRule",
+    "InspectFormatargspecRule",
+    "InspectGetargspecRule",
+    "RemovedStdlibImportRule",
+    "CORE_RULES",
+    "IDIOMATIC_RULES",
+    "OPTIN_RULE_GROUPS",
+]

--- a/refactor/rules/py312_migration/asyncio_modern.py
+++ b/refactor/rules/py312_migration/asyncio_modern.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.common import clone
+from refactor.core import Rule
+
+
+class AsyncioGetEventLoopRule(Rule):
+    """Replace asyncio.get_event_loop() with asyncio.get_running_loop() in async contexts.
+
+    This rule only transforms calls inside async def function bodies. Calls in sync
+    functions or at module level are left unchanged.
+
+    Example:
+        async def foo():
+            loop = asyncio.get_event_loop()  # -> asyncio.get_running_loop()
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.Call)
+
+        # Check if this is asyncio.get_event_loop()
+        func = node.func
+        assert isinstance(func, ast.Attribute)
+        assert func.attr == "get_event_loop"
+        assert isinstance(func.value, ast.Name)
+        assert func.value.id == "asyncio"
+
+        # Walk up the ancestry chain to find the enclosing function
+        parent_field, parent_node = self.context.ancestry.infer(node)
+
+        while parent_node is not None:
+            if isinstance(parent_node, ast.AsyncFunctionDef):
+                # Found an async def — this is a valid context for get_running_loop()
+                break
+            if isinstance(parent_node, (ast.FunctionDef, ast.Lambda)):
+                # Found a sync function or lambda — not a valid context
+                assert False
+            # Continue walking up
+            parent_field, parent_node = self.context.ancestry.infer(parent_node)
+        else:
+            # Reached module level without finding an async def
+            assert False
+
+        # Transform: replace get_event_loop with get_running_loop
+        new_node = clone(node)
+        new_func = clone(func)
+        new_func.attr = "get_running_loop"
+        new_node.func = new_func
+        return Replace(node, new_node)

--- a/refactor/rules/py312_migration/asyncio_modern.py
+++ b/refactor/rules/py312_migration/asyncio_modern.py
@@ -37,12 +37,12 @@ class AsyncioGetEventLoopRule(Rule):
                 break
             if isinstance(parent_node, (ast.FunctionDef, ast.Lambda)):
                 # Found a sync function or lambda — not a valid context
-                assert False
+                return None
             # Continue walking up
             parent_field, parent_node = self.context.ancestry.infer(parent_node)
         else:
             # Reached module level without finding an async def
-            assert False
+            return None
 
         # Transform: replace get_event_loop with get_running_loop
         new_node = clone(node)

--- a/refactor/rules/py312_migration/datetime_modern.py
+++ b/refactor/rules/py312_migration/datetime_modern.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.common import clone
+from refactor.core import Rule
+
+
+def _resolve_datetime_chain(node: ast.expr) -> list[str] | None:
+    """
+    Resolve a chain of attribute accesses to check if it represents datetime or datetime.datetime.
+
+    Returns a list of identifiers in the chain (e.g., ['datetime'] or ['datetime', 'datetime']),
+    or None if the chain cannot be resolved to datetime.
+
+    Examples:
+        Name('datetime')                             -> ['datetime']
+        Attribute(Name('datetime'), 'datetime')      -> ['datetime', 'datetime']
+        Name('foo')                                  -> ['foo'] (we accept this; caller disambiguates)
+    """
+    chain = []
+    current = node
+
+    while isinstance(current, ast.Attribute):
+        chain.append(current.attr)
+        current = current.value
+
+    if isinstance(current, ast.Name):
+        chain.append(current.id)
+        chain.reverse()
+        return chain
+
+    return None
+
+
+class DatetimeUtcnowRule(Rule):
+    """Replace datetime.utcnow() with datetime.now(datetime.UTC).
+
+    Handles:
+    - datetime.utcnow()              -> datetime.now(datetime.UTC)
+    - datetime.datetime.utcnow()     -> datetime.datetime.now(datetime.datetime.UTC)
+    - from datetime import datetime; datetime.utcnow()  -> datetime.now(datetime.UTC)
+
+    NOTE: This rule matches ANY X.utcnow() pattern based on AST structure alone, not semantic
+    analysis. While utcnow() is almost exclusively a datetime method, false positives are possible
+    (e.g., foo.utcnow() where foo is some other object). This is acceptable because:
+    1. utcnow is overwhelmingly a datetime method in practice
+    2. The replacement pattern is idiomatic for all datetime variations
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.Call)
+        assert isinstance(node.func, ast.Attribute)
+        assert node.func.attr == "utcnow"
+
+        # Extract the object chain (e.g., datetime or datetime.datetime)
+        obj_chain = _resolve_datetime_chain(node.func.value)
+        assert obj_chain is not None
+
+        # Clone the Call node and build the replacement
+        new_node = clone(node)
+        new_node.func = clone(new_node.func)
+
+        # Change method name from utcnow to now
+        new_node.func.attr = "now"
+
+        # Build the UTC argument: <chain>.UTC
+        # Reconstruct the same chain as the object, then append .UTC
+        utc_expr: ast.expr = ast.Name(id=obj_chain[0], ctx=ast.Load())
+        for attr in obj_chain[1:]:
+            utc_expr = ast.Attribute(value=utc_expr, attr=attr, ctx=ast.Load())
+        utc_expr = ast.Attribute(value=utc_expr, attr="UTC", ctx=ast.Load())
+
+        # Add UTC as positional argument
+        new_node.args = [utc_expr] + list(new_node.args)
+
+        ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)
+
+
+class DatetimeUtcfromtimestampRule(Rule):
+    """Replace datetime.utcfromtimestamp(ts) with datetime.fromtimestamp(ts, tz=datetime.UTC).
+
+    Handles:
+    - datetime.utcfromtimestamp(ts)              -> datetime.fromtimestamp(ts, tz=datetime.UTC)
+    - datetime.datetime.utcfromtimestamp(ts)     -> datetime.datetime.fromtimestamp(ts, tz=datetime.datetime.UTC)
+
+    Preserves existing positional and keyword arguments, inserting tz= after positional args.
+
+    NOTE: Like DatetimeUtcnowRule, this matches any X.utcfromtimestamp() pattern. False positives
+    are unlikely but theoretically possible.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.Call)
+        assert isinstance(node.func, ast.Attribute)
+        assert node.func.attr == "utcfromtimestamp"
+
+        # Extract the object chain
+        obj_chain = _resolve_datetime_chain(node.func.value)
+        assert obj_chain is not None
+
+        # Clone the Call node
+        new_node = clone(node)
+        new_node.func = clone(new_node.func)
+
+        # Change method name from utcfromtimestamp to fromtimestamp
+        new_node.func.attr = "fromtimestamp"
+
+        # Build the UTC argument: <chain>.UTC
+        utc_expr: ast.expr = ast.Name(id=obj_chain[0], ctx=ast.Load())
+        for attr in obj_chain[1:]:
+            utc_expr = ast.Attribute(value=utc_expr, attr=attr, ctx=ast.Load())
+        utc_expr = ast.Attribute(value=utc_expr, attr="UTC", ctx=ast.Load())
+
+        # Add tz=<chain>.UTC keyword argument
+        tz_keyword = ast.keyword(arg="tz", value=utc_expr)
+
+        # Preserve existing keywords and append tz=
+        new_node.keywords = list(new_node.keywords) + [tz_keyword]
+
+        ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)

--- a/refactor/rules/py312_migration/distutils.py
+++ b/refactor/rules/py312_migration/distutils.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.common import clone
+from refactor.core import Rule
+
+
+class DistutilsCoreSetupRule(Rule):
+    """Replace 'from distutils.core import ...' with 'from setuptools import ...'."""
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ImportFrom)
+        assert node.module == "distutils.core"
+        new_node = clone(node)
+        new_node.module = "setuptools"
+        return Replace(node, new_node)
+
+
+class DistutilsCommandRule(Rule):
+    """Replace 'from distutils.command.X import ...' with 'from setuptools.command.X import ...'."""
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ImportFrom)
+        assert node.module is not None
+        assert node.module.startswith("distutils.command.")
+        new_node = clone(node)
+        new_node.module = "setuptools.command." + node.module[len("distutils.command.") :]
+        return Replace(node, new_node)
+
+
+class DistutilsVersionRule(Rule):
+    """Replace 'from distutils.version import LooseVersion/StrictVersion' with 'from packaging.version import Version'.
+
+    Preserves callsite compatibility by keeping the original name as an alias.
+    If an 'as' alias is already present, keeps it unchanged on Version.
+    """
+
+    _VERSION_NAMES = frozenset({"LooseVersion", "StrictVersion"})
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ImportFrom)
+        assert node.module == "distutils.version"
+        imported = {alias.name for alias in node.names}
+        assert imported & self._VERSION_NAMES
+        new_aliases: list[ast.alias] = []
+        for alias in node.names:
+            if alias.name in self._VERSION_NAMES:
+                # Preserve the effective name at the callsite
+                effective_name = alias.asname if alias.asname else alias.name
+                new_aliases.append(ast.alias(name="Version", asname=effective_name))
+            else:
+                new_aliases.append(clone(alias))
+        new_node = clone(node)
+        new_node.module = "packaging.version"
+        new_node.names = new_aliases
+        return Replace(node, new_node)
+
+
+class DistutilsSpawnRule(Rule):
+    """Replace 'from distutils.spawn import find_executable' with 'from shutil import which as find_executable'."""
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ImportFrom)
+        assert node.module == "distutils.spawn"
+        spawn_aliases = [alias for alias in node.names if alias.name == "find_executable"]
+        assert len(spawn_aliases) > 0
+        new_aliases: list[ast.alias] = []
+        for alias in node.names:
+            if alias.name == "find_executable":
+                # Preserve explicit alias if present; otherwise keep find_executable as alias
+                effective_name = alias.asname if alias.asname else "find_executable"
+                new_aliases.append(ast.alias(name="which", asname=effective_name))
+            else:
+                new_aliases.append(clone(alias))
+        new_node = clone(node)
+        new_node.module = "shutil"
+        new_node.names = new_aliases
+        return Replace(node, new_node)
+
+
+class DistutilsUtilStrtoboolRule(Rule):
+    """Replace 'from distutils.util import strtobool' with an inline strtobool() definition."""
+
+    _STRTOBOOL_SOURCE = '''\
+def strtobool(val: str) -> int:
+    """Replacement for removed distutils.util.strtobool."""
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    raise ValueError(f"invalid truth value {val!r}")
+'''
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ImportFrom)
+        assert node.module == "distutils.util"
+        strtobool_aliases = [alias for alias in node.names if alias.name == "strtobool"]
+        assert len(strtobool_aliases) > 0
+        func_def = ast.parse(self._STRTOBOOL_SOURCE).body[0]
+        return Replace(node, func_def)
+
+
+class DistutilsSysconfigRule(Rule):
+    """Replace 'from distutils.sysconfig import ...' with 'from sysconfig import ...'."""
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ImportFrom)
+        assert node.module == "distutils.sysconfig"
+        new_node = clone(node)
+        new_node.module = "sysconfig"
+        return Replace(node, new_node)
+
+
+class DistutilsLogRule(Rule):
+    """Replace 'from distutils import log' with 'import logging'."""
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ImportFrom)
+        assert node.module == "distutils"
+        log_aliases = [alias for alias in node.names if alias.name == "log"]
+        assert len(log_aliases) > 0
+        new_node = ast.Import(names=[ast.alias(name="logging", asname=None)])
+        return Replace(node, new_node)

--- a/refactor/rules/py312_migration/inspect_modern.py
+++ b/refactor/rules/py312_migration/inspect_modern.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.actions import InsertBefore
+from refactor.common import clone
+from refactor.core import Rule
+
+
+class InspectGetargspecRule(Rule):
+    """Replace inspect.getargspec(fn) with inspect.getfullargspec(fn).
+
+    inspect.getargspec was deprecated in Python 3.0 and removed in 3.11.
+    The direct replacement is inspect.getfullargspec.
+
+    Example:
+        inspect.getargspec(fn)  ->  inspect.getfullargspec(fn)
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.Call)
+        assert isinstance(node.func, ast.Attribute)
+        assert isinstance(node.func.value, ast.Name)
+        assert node.func.value.id == "inspect"
+        assert node.func.attr == "getargspec"
+
+        new_node = clone(node)
+        new_node.func = clone(node.func)
+        new_node.func.attr = "getfullargspec"
+        return Replace(node, new_node)
+
+
+class InspectFormatargspecRule(Rule):
+    """Flag inspect.formatargspec calls with a TODO comment.
+
+    inspect.formatargspec has no direct 1:1 replacement (removed in 3.11).
+    The recommended approach is to use inspect.signature(fn) and str(sig),
+    or iterate parameters manually.
+
+    This rule inserts a TODO comment before the statement containing the call.
+
+    Example:
+        result = inspect.formatargspec(args)
+        # becomes:
+        TODO(py312): inspect.formatargspec removed; use inspect.signature(fn) and str(sig)
+        result = inspect.formatargspec(args)
+    """
+
+    def match(self, node: ast.AST) -> InsertBefore | None:
+        assert isinstance(node, ast.stmt)
+
+        # Walk the statement to find any inspect.formatargspec calls
+        found_formatargspec = False
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call):
+                if isinstance(child.func, ast.Attribute):
+                    if isinstance(child.func.value, ast.Name):
+                        if child.func.value.id == "inspect" and child.func.attr == "formatargspec":
+                            found_formatargspec = True
+                            break
+
+        assert found_formatargspec
+
+        # Check if the immediately preceding statement is already the TODO marker
+        tree = self.context.tree
+        assert isinstance(tree, ast.Module)
+
+        # Find the index of this statement in the module body
+        stmt_index = None
+        for i, stmt in enumerate(tree.body):
+            if stmt is node:
+                stmt_index = i
+                break
+
+        # If this is not the first statement, check if the previous one is our TODO marker
+        if stmt_index is not None and stmt_index > 0:
+            prev_stmt = tree.body[stmt_index - 1]
+            if isinstance(prev_stmt, ast.Expr):
+                if isinstance(prev_stmt.value, ast.Constant):
+                    if isinstance(prev_stmt.value.value, str):
+                        if "TODO(py312): inspect.formatargspec" in prev_stmt.value.value:
+                            # Marker already exists, don't add again
+                            return None
+
+        # Create the TODO marker as a string constant expression
+        marker = ast.Expr(
+            value=ast.Constant(
+                value="TODO(py312): inspect.formatargspec removed; use inspect.signature(fn) and str(sig)"
+            )
+        )
+        ast.fix_missing_locations(marker)
+
+        return InsertBefore(node, marker)

--- a/refactor/rules/py312_migration/stdlib_removed.py
+++ b/refactor/rules/py312_migration/stdlib_removed.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.actions import InsertBefore
+from refactor.common import clone
+from refactor.core import Rule
+
+# PEP 594 modules removed in Python 3.12 or 3.13
+_REMOVED_MODULES = frozenset(
+    {
+        "asynchat",
+        "asyncore",
+        "smtpd",
+        "imghdr",
+        "sndhdr",
+        "audioop",
+        "aifc",
+        "sunau",
+        "chunk",
+        "cgi",
+        "cgitb",
+        "crypt",
+        "spwd",
+        "nis",
+        "pipes",
+        "mailcap",
+        "nntplib",
+        "telnetlib",
+        "uu",
+        "ossaudiodev",
+        "xdrlib",
+        "msilib",
+    }
+)
+
+
+def _marker_already_exists(tree: ast.Module, node: ast.stmt, module_name: str) -> bool:
+    """Check if a marker comment for this module already exists immediately before the import."""
+    # Find the index of the current node in the tree body
+    try:
+        node_idx = tree.body.index(node)
+    except ValueError:
+        return False
+
+    if node_idx == 0:
+        return False
+
+    prev_stmt = tree.body[node_idx - 1]
+    # Check if the previous statement is an Expr with a constant string marker
+    if isinstance(prev_stmt, ast.Expr) and isinstance(prev_stmt.value, ast.Constant):
+        marker_value = prev_stmt.value.value
+        if isinstance(marker_value, str) and f"TODO(py312): '{module_name}'" in marker_value:
+            return True
+
+    return False
+
+
+class RemovedStdlibImportRule(Rule):
+    """Insert a warning comment before imports of PEP 594 removed stdlib modules.
+
+    When a module from _REMOVED_MODULES is detected via `import X` or `from X import ...`,
+    insert a marker expression (string constant) on the line immediately before the import
+    to warn the developer that the module has been removed in Python 3.12 or 3.13.
+
+    Example:
+        import asynchat
+        ->
+        "TODO(py312): 'asynchat' is removed in Python 3.13"
+        import asynchat
+    """
+
+    def match(self, node: ast.AST) -> InsertBefore | None:
+        assert isinstance(node, (ast.Import, ast.ImportFrom))
+
+        tree = self.context.tree
+        assert isinstance(tree, ast.Module)
+
+        removed_module = None
+
+        if isinstance(node, ast.Import):
+            # Check if any of the imported names are in _REMOVED_MODULES
+            for alias in node.names:
+                if alias.name in _REMOVED_MODULES:
+                    removed_module = alias.name
+                    break
+        elif isinstance(node, ast.ImportFrom):
+            # Check if the module being imported from is in _REMOVED_MODULES
+            if node.module and node.module in _REMOVED_MODULES:
+                removed_module = node.module
+
+        assert removed_module is not None
+
+        # Avoid duplicating markers: skip if one already exists immediately before
+        if _marker_already_exists(tree, node, removed_module):
+            return None
+
+        # Create a marker expression (string constant) to prepend
+        marker_msg = f"TODO(py312): '{removed_module}' is removed in Python 3.13"
+        marker_node = ast.Expr(value=ast.Constant(value=marker_msg))
+        ast.fix_missing_locations(marker_node)
+
+        return InsertBefore(node, marker_node)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,4 @@ python_requires = >=3.9
 [options.entry_points]
 console_scripts =
     refactor = refactor.__main__:main
+    refactor-py312 = refactor.cli_py312:main

--- a/tests/test_py312_asyncio.py
+++ b/tests/test_py312_asyncio.py
@@ -1,0 +1,107 @@
+"""Tests for AsyncioGetEventLoopRule (Phase 1)."""
+
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.py312_migration.asyncio_modern import AsyncioGetEventLoopRule
+
+
+def _run(*rules, source: str) -> str:
+    """Run refactor rules on source code."""
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+class TestAsyncioGetEventLoopRule:
+    """Test AsyncioGetEventLoopRule transformations."""
+
+    def test_inside_async_def(self):
+        """Test: asyncio.get_event_loop() inside async def should be transformed."""
+        source = """\
+            import asyncio
+
+            async def foo():
+                loop = asyncio.get_event_loop()
+                return loop
+        """
+        expected = """\
+            import asyncio
+
+            async def foo():
+                loop = asyncio.get_running_loop()
+                return loop
+        """
+        result = _run(AsyncioGetEventLoopRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_inside_sync_def_no_transform(self):
+        """Test: asyncio.get_event_loop() inside sync def should NOT be transformed."""
+        source = """\
+            import asyncio
+
+            def foo():
+                loop = asyncio.get_event_loop()
+                return loop
+        """
+        result = _run(AsyncioGetEventLoopRule, source=source)
+        assert result == textwrap.dedent(source)
+
+    def test_at_module_level_no_transform(self):
+        """Test: asyncio.get_event_loop() at module level should NOT be transformed."""
+        source = """\
+            import asyncio
+
+            loop = asyncio.get_event_loop()
+        """
+        result = _run(AsyncioGetEventLoopRule, source=source)
+        assert result == textwrap.dedent(source)
+
+    def test_nested_sync_in_async_no_transform(self):
+        """Test: nested sync def inside async def — call in sync def should NOT be transformed."""
+        source = """\
+            import asyncio
+
+            async def outer():
+                def inner():
+                    loop = asyncio.get_event_loop()
+                    return loop
+                return inner()
+        """
+        result = _run(AsyncioGetEventLoopRule, source=source)
+        assert result == textwrap.dedent(source)
+
+    def test_nested_async_in_sync_should_transform(self):
+        """Test: nested async def inside sync def — call in async def SHOULD be transformed."""
+        source = """\
+            import asyncio
+
+            def outer():
+                async def inner():
+                    loop = asyncio.get_event_loop()
+                    return loop
+                return inner()
+        """
+        expected = """\
+            import asyncio
+
+            def outer():
+                async def inner():
+                    loop = asyncio.get_running_loop()
+                    return loop
+                return inner()
+        """
+        result = _run(AsyncioGetEventLoopRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_get_running_loop_unchanged(self):
+        """Test: asyncio.get_running_loop() in async def should NOT be transformed (idempotent)."""
+        source = """\
+            import asyncio
+
+            async def foo():
+                loop = asyncio.get_running_loop()
+                return loop
+        """
+        result = _run(AsyncioGetEventLoopRule, source=source)
+        assert result == textwrap.dedent(source)

--- a/tests/test_py312_datetime.py
+++ b/tests/test_py312_datetime.py
@@ -1,0 +1,123 @@
+"""Tests for datetime modernization rules (py312_migration.datetime_modern)."""
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.py312_migration.datetime_modern import (
+    DatetimeUtcfromtimestampRule,
+    DatetimeUtcnowRule,
+)
+
+
+def _run(*rules, source: str) -> str:
+    """Run refactor Session with given rules on source code."""
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+class TestDatetimeUtcnowRule:
+    """Tests for DatetimeUtcnowRule."""
+
+    def test_simple_datetime_utcnow(self):
+        """Test datetime.utcnow() -> datetime.now(datetime.UTC)."""
+        source = """\
+        import datetime
+        dt = datetime.utcnow()
+        """
+        expected = """\
+        import datetime
+        dt = datetime.now(datetime.UTC)
+        """
+        result = _run(DatetimeUtcnowRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_qualified_datetime_datetime_utcnow(self):
+        """Test datetime.datetime.utcnow() -> datetime.datetime.now(datetime.datetime.UTC)."""
+        source = """\
+        import datetime
+        dt = datetime.datetime.utcnow()
+        """
+        expected = """\
+        import datetime
+        dt = datetime.datetime.now(datetime.datetime.UTC)
+        """
+        result = _run(DatetimeUtcnowRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_imported_datetime_class_utcnow(self):
+        """Test with 'from datetime import datetime; datetime.utcnow()'."""
+        source = """\
+        from datetime import datetime
+        dt = datetime.utcnow()
+        """
+        expected = """\
+        from datetime import datetime
+        dt = datetime.now(datetime.UTC)
+        """
+        result = _run(DatetimeUtcnowRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_arbitrary_object_utcnow_matches(self):
+        """Test that X.utcnow() matches even when X is not datetime (documents behavior)."""
+        source = """\
+        foo = SomeObject()
+        result = foo.utcnow()
+        """
+        expected = """\
+        foo = SomeObject()
+        result = foo.now(foo.UTC)
+        """
+        result = _run(DatetimeUtcnowRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+
+class TestDatetimeUtcfromtimestampRule:
+    """Tests for DatetimeUtcfromtimestampRule."""
+
+    def test_simple_datetime_utcfromtimestamp(self):
+        """Test datetime.utcfromtimestamp(ts) -> datetime.fromtimestamp(ts, tz=datetime.UTC)."""
+        source = """\
+        import datetime
+        dt = datetime.utcfromtimestamp(1234567890)
+        """
+        expected = """\
+        import datetime
+        dt = datetime.fromtimestamp(1234567890, tz=datetime.UTC)
+        """
+        result = _run(DatetimeUtcfromtimestampRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_qualified_datetime_datetime_utcfromtimestamp(self):
+        """Test datetime.datetime.utcfromtimestamp(ts) -> datetime.datetime.fromtimestamp(ts, tz=datetime.datetime.UTC)."""
+        source = """\
+        import datetime
+        dt = datetime.datetime.utcfromtimestamp(1234567890)
+        """
+        expected = """\
+        import datetime
+        dt = datetime.datetime.fromtimestamp(1234567890, tz=datetime.datetime.UTC)
+        """
+        result = _run(DatetimeUtcfromtimestampRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_with_existing_keyword_arg(self):
+        """Test that existing keyword args are preserved."""
+        source = """\
+        import datetime
+        dt = datetime.utcfromtimestamp(ts, x=1)
+        """
+        expected = """\
+        import datetime
+        dt = datetime.fromtimestamp(ts, x=1, tz=datetime.UTC)
+        """
+        result = _run(DatetimeUtcfromtimestampRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_idempotency(self):
+        """Test that already-converted code does not re-fire the rule."""
+        source = """\
+        import datetime
+        dt = datetime.fromtimestamp(1234567890, tz=datetime.UTC)
+        """
+        result = _run(DatetimeUtcfromtimestampRule, source=source)
+        # Should be unchanged (rule only matches utcfromtimestamp, not fromtimestamp)
+        assert result == textwrap.dedent(source)

--- a/tests/test_py312_distutils.py
+++ b/tests/test_py312_distutils.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.py312_migration.distutils import (
+    DistutilsCommandRule,
+    DistutilsCoreSetupRule,
+    DistutilsLogRule,
+    DistutilsSpawnRule,
+    DistutilsSysconfigRule,
+    DistutilsUtilStrtoboolRule,
+    DistutilsVersionRule,
+)
+
+
+def _run(*rules, source: str) -> str:
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+# ---------------------------------------------------------------------------
+# DistutilsCoreSetupRule
+# ---------------------------------------------------------------------------
+
+
+def test_distutils_core_setup_replaced():
+    source = """\
+        from distutils.core import setup
+        setup(name="foo")
+        """
+    expected = """\
+        from setuptools import setup
+        setup(name="foo")
+        """
+    assert _run(DistutilsCoreSetupRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_core_setup_multiple_names():
+    source = """\
+        from distutils.core import setup, Extension
+        """
+    expected = """\
+        from setuptools import setup, Extension
+        """
+    assert _run(DistutilsCoreSetupRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_core_setup_noop_other_module():
+    source = """\
+        from distutils.util import strtobool
+        """
+    result = _run(DistutilsCoreSetupRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+# ---------------------------------------------------------------------------
+# DistutilsCommandRule
+# ---------------------------------------------------------------------------
+
+
+def test_distutils_command_replaced():
+    source = """\
+        from distutils.command.build import build
+        """
+    expected = """\
+        from setuptools.command.build import build
+        """
+    assert _run(DistutilsCommandRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_command_install_replaced():
+    source = """\
+        from distutils.command.install import install
+        """
+    expected = """\
+        from setuptools.command.install import install
+        """
+    assert _run(DistutilsCommandRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_command_noop_non_command():
+    source = """\
+        from distutils.core import setup
+        """
+    result = _run(DistutilsCommandRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+# ---------------------------------------------------------------------------
+# DistutilsVersionRule
+# ---------------------------------------------------------------------------
+
+
+def test_distutils_version_loose_replaced():
+    source = """\
+        from distutils.version import LooseVersion
+        """
+    expected = """\
+        from packaging.version import Version as LooseVersion
+        """
+    assert _run(DistutilsVersionRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_version_loose_with_alias():
+    source = """\
+        from distutils.version import LooseVersion as LV
+        """
+    expected = """\
+        from packaging.version import Version as LV
+        """
+    assert _run(DistutilsVersionRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_version_noop_other_module():
+    source = """\
+        from distutils.core import setup
+        """
+    result = _run(DistutilsVersionRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+# ---------------------------------------------------------------------------
+# DistutilsSpawnRule
+# ---------------------------------------------------------------------------
+
+
+def test_distutils_spawn_find_executable_replaced():
+    source = """\
+        from distutils.spawn import find_executable
+        """
+    expected = """\
+        from shutil import which as find_executable
+        """
+    assert _run(DistutilsSpawnRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_spawn_find_executable_with_alias():
+    source = """\
+        from distutils.spawn import find_executable as fe
+        """
+    expected = """\
+        from shutil import which as fe
+        """
+    assert _run(DistutilsSpawnRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_spawn_noop_other_name():
+    source = """\
+        from distutils.spawn import spawn
+        """
+    result = _run(DistutilsSpawnRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+# ---------------------------------------------------------------------------
+# DistutilsUtilStrtoboolRule
+# ---------------------------------------------------------------------------
+
+
+def test_distutils_util_strtobool_replaced():
+    source = """\
+        from distutils.util import strtobool
+        result = strtobool("yes")
+        """
+    result = _run(DistutilsUtilStrtoboolRule, source=source)
+    assert "def strtobool(val: str) -> int:" in result
+    assert "from distutils.util import strtobool" not in result
+
+
+def test_distutils_util_strtobool_body_correct():
+    source = """\
+        from distutils.util import strtobool
+        """
+    result = _run(DistutilsUtilStrtoboolRule, source=source)
+    assert "raise ValueError" in result
+    assert ("'y', 'yes'" in result) or ("'y'" in result)
+
+
+def test_distutils_util_strtobool_noop_other_name():
+    source = """\
+        from distutils.util import byte_compile
+        """
+    result = _run(DistutilsUtilStrtoboolRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+# ---------------------------------------------------------------------------
+# DistutilsSysconfigRule
+# ---------------------------------------------------------------------------
+
+
+def test_distutils_sysconfig_replaced():
+    source = """\
+        from distutils.sysconfig import get_python_lib
+        """
+    expected = """\
+        from sysconfig import get_python_lib
+        """
+    assert _run(DistutilsSysconfigRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_sysconfig_multiple_names():
+    source = """\
+        from distutils.sysconfig import get_python_lib, get_config_var
+        """
+    expected = """\
+        from sysconfig import get_python_lib, get_config_var
+        """
+    assert _run(DistutilsSysconfigRule, source=source) == textwrap.dedent(expected)
+
+
+def test_distutils_sysconfig_noop_other_module():
+    source = """\
+        from distutils.core import setup
+        """
+    result = _run(DistutilsSysconfigRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+# ---------------------------------------------------------------------------
+# DistutilsLogRule
+# ---------------------------------------------------------------------------
+
+
+def test_distutils_log_replaced():
+    source = """\
+        from distutils import log
+        log.info("building")
+        """
+    result = _run(DistutilsLogRule, source=source)
+    assert "import logging" in result
+    assert "from distutils import log" not in result
+
+
+def test_distutils_log_noop_other_name():
+    source = """\
+        from distutils import core
+        """
+    result = _run(DistutilsLogRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_distutils_log_noop_distutils_core_module():
+    source = """\
+        from distutils.core import setup
+        """
+    result = _run(DistutilsLogRule, source=source)
+    assert result == textwrap.dedent(source)

--- a/tests/test_py312_inspect.py
+++ b/tests/test_py312_inspect.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.py312_migration.inspect_modern import (
+    InspectFormatargspecRule,
+    InspectGetargspecRule,
+)
+
+
+def _run(*rules, source: str) -> str:
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+class TestInspectGetargspecRule:
+    """Tests for InspectGetargspecRule: inspect.getargspec -> inspect.getfullargspec."""
+
+    def test_basic_replacement(self) -> None:
+        """Test basic inspect.getargspec() call is replaced."""
+        source = """\
+            import inspect
+            result = inspect.getargspec(fn)
+        """
+        expected = """\
+            import inspect
+            result = inspect.getfullargspec(fn)
+        """
+        output = _run(InspectGetargspecRule, source=source)
+        assert output == textwrap.dedent(expected)
+
+    def test_with_kwargs(self) -> None:
+        """Test that keyword arguments are preserved."""
+        source = """\
+            import inspect
+            result = inspect.getargspec(fn, defaults=None)
+        """
+        expected = """\
+            import inspect
+            result = inspect.getfullargspec(fn, defaults=None)
+        """
+        output = _run(InspectGetargspecRule, source=source)
+        assert output == textwrap.dedent(expected)
+
+    def test_no_match_getfullargspec(self) -> None:
+        """Test that getfullargspec calls are not re-fired."""
+        source = """\
+            import inspect
+            result = inspect.getfullargspec(fn)
+        """
+        output = _run(InspectGetargspecRule, source=source)
+        assert output == textwrap.dedent(source)
+
+
+class TestInspectFormatargspecRule:
+    """Tests for InspectFormatargspecRule: insert TODO marker before formatargspec."""
+
+    def test_basic_call(self) -> None:
+        """Test TODO marker inserted before a bare formatargspec call."""
+        source = """\
+            import inspect
+            result = inspect.formatargspec(args)
+        """
+        output = _run(InspectFormatargspecRule, source=source)
+        lines = output.strip().split("\n")
+        # Expect: import, empty line, TODO marker, then the original call
+        assert "TODO(py312): inspect.formatargspec" in output
+        assert "result = inspect.formatargspec(args)" in output
+        # The TODO should appear before the call in the output
+        assert output.index("TODO(py312)") < output.index("result = inspect.formatargspec")
+
+    def test_in_assignment(self) -> None:
+        """Test TODO marker inserted before an assignment containing formatargspec."""
+        source = """\
+            import inspect
+            result = inspect.formatargspec(args, varargs='args')
+        """
+        output = _run(InspectFormatargspecRule, source=source)
+        assert "TODO(py312): inspect.formatargspec" in output
+        assert "result = inspect.formatargspec(args, varargs='args')" in output
+        # The TODO should appear before the call
+        assert output.index("TODO(py312)") < output.index("result = inspect.formatargspec")
+
+    def test_idempotency(self) -> None:
+        """Test that running twice produces the same output (no duplicate markers)."""
+        source = """\
+            import inspect
+            result = inspect.formatargspec(args)
+        """
+        # Run once
+        output1 = _run(InspectFormatargspecRule, source=source)
+        # Run again on the output
+        output2 = _run(InspectFormatargspecRule, source=output1)
+        # Count occurrences of the TODO marker
+        count1 = output1.count("TODO(py312): inspect.formatargspec")
+        count2 = output2.count("TODO(py312): inspect.formatargspec")
+        # Should have exactly one marker in both cases
+        assert count1 == 1
+        assert count2 == 1

--- a/tests/test_py312_stdlib_removed.py
+++ b/tests/test_py312_stdlib_removed.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.py312_migration.stdlib_removed import RemovedStdlibImportRule
+
+
+def _run(*rules, source: str) -> str:
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+def test_import_asynchat():
+    """Test that importing asynchat (removed module) gets a marker prepended."""
+    source = """\
+        import asynchat
+        """
+    result = _run(RemovedStdlibImportRule, source=source)
+    assert "TODO(py312): 'asynchat' is removed in Python 3.13" in result
+    assert "import asynchat" in result
+
+
+def test_from_smtpd_import():
+    """Test that 'from smtpd import ...' gets a marker prepended."""
+    source = """\
+        from smtpd import DebuggingServer
+        """
+    result = _run(RemovedStdlibImportRule, source=source)
+    assert "TODO(py312): 'smtpd' is removed in Python 3.13" in result
+    assert "from smtpd import DebuggingServer" in result
+
+
+def test_import_os_not_removed():
+    """Test that importing 'os' (not removed) produces no marker."""
+    source = """\
+        import os
+        """
+    result = _run(RemovedStdlibImportRule, source=source)
+    assert "TODO(py312)" not in result
+    assert result == textwrap.dedent(source)
+
+
+def test_idempotency():
+    """Test that running the rule twice does not duplicate markers."""
+    source = """\
+        import asynchat
+        """
+    result1 = _run(RemovedStdlibImportRule, source=source)
+    # Run again on the output
+    result2 = _run(RemovedStdlibImportRule, source=result1)
+    # Should be identical; marker should not be duplicated
+    assert result1 == result2
+    # Count marker occurrences
+    marker_count = result2.count("TODO(py312): 'asynchat'")
+    assert marker_count == 1, f"Expected 1 marker, got {marker_count}"
+
+
+def test_multiple_removed_imports():
+    """Test that multiple removed imports each get their own marker."""
+    source = """\
+        import asynchat
+        import smtpd
+        from aifc import open
+        """
+    result = _run(RemovedStdlibImportRule, source=source)
+    assert "TODO(py312): 'asynchat' is removed in Python 3.13" in result
+    assert "TODO(py312): 'smtpd' is removed in Python 3.13" in result
+    assert "TODO(py312): 'aifc' is removed in Python 3.13" in result
+    assert "import asynchat" in result
+    assert "import smtpd" in result
+    assert "from aifc import open" in result


### PR DESCRIPTION
## Summary

First of three PRs implementing the comprehensive Python 3.12 rule pack defined in `~/.claude/plans/py312-rule-pack-comprehensive.md`. This PR delivers **Phase 1 — breaking-change rules** plus the `refactor-py312` console_scripts entrypoint that consumers (Hummingbot) require.

## What's in this PR

### Rule pack (commit `a784e00`)

13 rules across 5 modules under `refactor/rules/py312_migration/`:

| Module | Rules | Purpose |
|---|---|---|
| `distutils.py` | 7 | distutils is removed entirely in py3.12 |
| `stdlib_removed.py` | 1 | PEP 594 removed-module flagger (asynchat, smtpd, etc.) |
| `datetime_modern.py` | 2 | `utcnow()` and `utcfromtimestamp()` are deprecated in 3.12 |
| `asyncio_modern.py` | 1 | `get_event_loop()` in async contexts → `get_running_loop()` |
| `inspect_modern.py` | 2 | `getargspec` removed; `formatargspec` flagger |

All rules subclass `refactor.core.Rule` following the exact pattern in `refactor/rules/pytest_migration.py` (assert guards → clone → return action). No new framework primitives added.

**46 tests** using the existing `textwrap.dedent` inline-fixture convention. Coverage per rule: positive transform, no-op, edge case.

### CLI entrypoint (commit `552c14f`)

`refactor/cli_py312.py` mirrors `refactor.__main__` shape with an `--enable=GROUP` flag for opt-in rule groups (reserved for Phase 3). Default invocation runs `CORE_RULES + IDIOMATIC_RULES`.

`setup.cfg` now exposes:
```
refactor       = refactor.__main__:main      (existing)
refactor-py312 = refactor.cli_py312:main     (new)
```

## Why this matters

Hummingbot's `custom_git_setup/scripts/hummingbot-branch-tracking.sh` calls `command -v refactor-py312` before running custom AST transforms on every `ci-base` sync. The binary did not exist; rebuilds silently logged `"refactor-py312 not found, skipping"`. After this PR (and a `pip install -e .` of refactor-applications in the consumer pixi env), that step will actually run.

pyupgrade still handles the ~80% of py312 modernization that's purely syntactic. This rule pack covers the long-tail semantic transforms pyupgrade can't (distutils replacements, async-context detection for `get_event_loop`, stdlib-removed flagging, etc.).

## What's NOT in this PR

- **Phase 2** — idiomatic modernization (`lru_cache`→`cache`, `ensure_future`→`create_task`, `StrEnum`/`IntEnum`, typing edge cases). Coming in a follow-up PR. `IDIOMATIC_RULES = []` placeholder is in `__init__.py`.
- **Phase 3** — opt-in high-risk transforms (`asyncio.timeout`, PEP 695 generics, `@override`, etc.). `OPTIN_RULE_GROUPS = {}` placeholder.
- **Framework changes** — `refactor.core`, `refactor.actions`, etc. untouched.

## Test plan

- [x] `pixi run -- pytest tests/test_py312_*.py -v` → 46/46 passing
- [x] `pixi run -- pip install -e .`
- [x] `command -v refactor-py312` → binary on PATH
- [x] `refactor-py312 --help` → argparse formats correctly
- [ ] Manual smoke test against Hummingbot tree (reviewer to run): `refactor-py312 --dont-apply ~/PycharmProjects/Hummingbot/hummingbot/hummingbot/` and inspect proposed diffs
- [ ] End-to-end: trigger Hummingbot cron rebuild and confirm `run_py312_transforms` actually executes (no longer logs skip)

## Architecture notes

- Branch target is `applications`, not `main`. This rule pack is application-specific (Hummingbot py312 migration) and not intended for upstream contribution to the framework.
- Framework `[tool.ruff] target-version` stays `py310` — refactor framework still supports >=3.9. Only the *transforms* target py3.12 idioms.
- `RemovedStdlibImportRule` does NOT auto-delete imports — it inserts a string-expression marker before each removed-module import. This is intentional: the developer must decide replacement strategy per case.
- `AsyncioGetEventLoopRule` walks `self.context.ancestry` to confirm the call is inside an `async def` body. Sync `def` callers are deliberately left untransformed (they may be legitimate event-loop bootstrap).

Plan: `~/.claude/plans/py312-rule-pack-comprehensive.md`