### PR TITLE
feat(py312): Phase 3 opt-in / high-risk modernization rule pack

### DIFF
--- a/refactor/cli_py312.py
+++ b/refactor/cli_py312.py
@@ -40,7 +40,7 @@ def main() -> int:
         metavar="GROUP",
         help=(
             "Enable an opt-in rule group. May be passed multiple times. "
-            "Available groups: " + ", ".join(sorted(OPTIN_RULE_GROUPS) | {"all"})
+            "Available groups: " + ", ".join(sorted(set(OPTIN_RULE_GROUPS) | {"all"}))
             if OPTIN_RULE_GROUPS
             else "Enable an opt-in rule group (no groups available in this build)."
         ),

--- a/refactor/rules/py312_migration/__init__.py
+++ b/refactor/rules/py312_migration/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from refactor.rules.py312_migration.asyncio_modern import (
     AsyncioEnsureFutureRule,
     AsyncioGetEventLoopRule,
+    AsyncioWaitForToTimeoutRule,
 )
 from refactor.rules.py312_migration.datetime_modern import (
     DatetimeUtcfromtimestampRule,
@@ -36,8 +37,13 @@ from refactor.rules.py312_migration.inspect_modern import (
     InspectFormatargspecRule,
     InspectGetargspecRule,
 )
+from refactor.rules.py312_migration.open_encoding import OpenEncodingRule
+from refactor.rules.py312_migration.override_decorator import OverrideDecoratorRule
+from refactor.rules.py312_migration.stdlib_additions import BatchedRule, PairwiseRule
 from refactor.rules.py312_migration.stdlib_removed import RemovedStdlibImportRule
 from refactor.rules.py312_migration.typing_modern import (
+    PEP695GenericClassRule,
+    PEP695TypeAliasRule,
     TypingDeprecatedAliasRule,
     TypingOptionalRule,
     TypingTypeRule,
@@ -78,11 +84,20 @@ IDIOMATIC_RULES = [
     TypingOptionalRule,
 ]
 
-OPTIN_RULE_GROUPS: dict[str, list] = {}  # Filled in Phase 3
+OPTIN_RULE_GROUPS = {
+    "asyncio-timeout": [AsyncioWaitForToTimeoutRule],
+    "pep695-types": [PEP695TypeAliasRule],
+    "pep695-generics": [PEP695GenericClassRule],
+    "override-decorator": [OverrideDecoratorRule],
+    "encoding-warning": [OpenEncodingRule],
+    "itertools-modern": [PairwiseRule, BatchedRule],
+}
 
 __all__ = [
     "AsyncioEnsureFutureRule",
     "AsyncioGetEventLoopRule",
+    "AsyncioWaitForToTimeoutRule",
+    "BatchedRule",
     "DatetimeUtcfromtimestampRule",
     "DatetimeUtcnowRule",
     "DistutilsCommandRule",
@@ -96,6 +111,11 @@ __all__ = [
     "InspectGetargspecRule",
     "IntEnumRule",
     "LruCacheToCacheRule",
+    "OpenEncodingRule",
+    "OverrideDecoratorRule",
+    "PEP695GenericClassRule",
+    "PEP695TypeAliasRule",
+    "PairwiseRule",
     "RemovedStdlibImportRule",
     "StrEnumRule",
     "TypingDeprecatedAliasRule",

--- a/refactor/rules/py312_migration/asyncio_modern.py
+++ b/refactor/rules/py312_migration/asyncio_modern.py
@@ -96,3 +96,96 @@ class AsyncioEnsureFutureRule(Rule):
         new_func.attr = "create_task"
         new_node.func = new_func
         return Replace(node, new_node)
+
+
+class AsyncioWaitForToTimeoutRule(Rule):
+    """Replace ``await asyncio.wait_for(coro, timeout=T)`` with the modern context-manager form.
+
+    Transforms:
+
+        async with asyncio.timeout(T):
+            await coro
+
+    **Opt-in only** (``--enable=asyncio-timeout``).  The two APIs have subtly
+    different cancellation semantics: ``wait_for`` cancels the inner task on
+    timeout whereas ``asyncio.timeout`` propagates a ``TimeoutError`` and
+    relies on structured concurrency; callers that catch
+    ``asyncio.TimeoutError`` / ``concurrent.futures.TimeoutError`` explicitly
+    may need manual adjustment after this transform.
+
+    Conservatively matches ONLY bare expression-statement awaits — i.e. the
+    ``await asyncio.wait_for(...)`` must be the entire statement, not the
+    right-hand side of an assignment or part of a larger expression.  That
+    guarantees the replacement (which produces a block, not an expression) is
+    always syntactically valid.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        # We match the enclosing ast.Expr statement, not the Call itself,
+        # because the replacement is a block statement (ast.AsyncWith) and
+        # must replace the whole statement node.
+        assert isinstance(node, ast.Expr)
+
+        # The statement value must be an Await expression.
+        value = node.value
+        assert isinstance(value, ast.Await)
+
+        # The awaited expression must be a Call.
+        call = value.value
+        assert isinstance(call, ast.Call)
+
+        # The call must be asyncio.wait_for(...)
+        func = call.func
+        assert isinstance(func, ast.Attribute)
+        assert func.attr == "wait_for"
+        assert isinstance(func.value, ast.Name)
+        assert func.value.id == "asyncio"
+
+        # Resolve positional args and the timeout value.
+        # Accepted forms:
+        #   wait_for(coro, timeout=T)  -> 1 positional arg, 1 keyword
+        #   wait_for(coro, T)          -> 2 positional args, 0 keywords
+        args = call.args
+        kwargs = call.keywords
+
+        if len(args) == 1 and len(kwargs) == 1 and kwargs[0].arg == "timeout":
+            coro_expr = args[0]
+            timeout_expr = kwargs[0].value
+        elif len(args) == 2 and len(kwargs) == 0:
+            coro_expr = args[0]
+            timeout_expr = args[1]
+        else:
+            return None
+
+        # Must be inside an async def — walk ancestry.
+        parent_field, parent_node = self.context.ancestry.infer(node)
+
+        while parent_node is not None:
+            if isinstance(parent_node, ast.AsyncFunctionDef):
+                break
+            if isinstance(parent_node, (ast.FunctionDef, ast.Lambda)):
+                return None
+            parent_field, parent_node = self.context.ancestry.infer(parent_node)
+        else:
+            return None
+
+        # Build: async with asyncio.timeout(T): await coro
+        new_stmt = ast.AsyncWith(
+            items=[
+                ast.withitem(
+                    context_expr=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="asyncio", ctx=ast.Load()),
+                            attr="timeout",
+                            ctx=ast.Load(),
+                        ),
+                        args=[timeout_expr],
+                        keywords=[],
+                    ),
+                    optional_vars=None,
+                )
+            ],
+            body=[ast.Expr(value=ast.Await(value=coro_expr))],
+        )
+        ast.fix_missing_locations(new_stmt)
+        return Replace(node, new_stmt)

--- a/refactor/rules/py312_migration/open_encoding.py
+++ b/refactor/rules/py312_migration/open_encoding.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.common import clone
+from refactor.core import Rule
+
+
+def _is_binary_mode(mode_node: ast.expr) -> bool:
+    """Return True if the mode expression is a string literal containing 'b'."""
+    if isinstance(mode_node, ast.Constant) and isinstance(mode_node.value, str):
+        return "b" in mode_node.value
+    # Non-literal expression — be conservative and treat as unknown (not binary)
+    return False
+
+
+def _mode_is_unknown_non_literal(mode_node: ast.expr) -> bool:
+    """Return True when the mode is a non-literal expression (variable, call, etc.)."""
+    return not isinstance(mode_node, ast.Constant)
+
+
+class OpenEncodingRule(Rule):
+    """Add ``encoding='utf-8'`` to bare ``open()`` calls in text mode.
+
+    py3.12 emits an EncodingWarning for ``open()`` without an explicit
+    ``encoding`` argument when the locale encoding differs from UTF-8; py3.15
+    will likely turn this into an error.
+
+    Conservative match:
+    - Only bare ``open(...)`` by name (not ``builtins.open``).
+    - Skips calls that already have an ``encoding=`` keyword.
+    - Skips calls where mode contains ``'b'`` (binary).
+    - Skips calls where mode is a non-literal expression (unknown — be safe).
+
+    Enable via ``--enable=encoding-warning``.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.Call)
+
+        # Only bare name open(...)
+        assert isinstance(node.func, ast.Name)
+        assert node.func.id == "open"
+
+        # Skip if encoding= is already present
+        existing_kw_names = {kw.arg for kw in node.keywords}
+        assert "encoding" not in existing_kw_names
+
+        # Determine mode from 2nd positional arg or mode= keyword
+        mode_node: ast.expr | None = None
+        if len(node.args) >= 2:
+            mode_node = node.args[1]
+        else:
+            for kw in node.keywords:
+                if kw.arg == "mode":
+                    mode_node = kw.value
+                    break
+
+        if mode_node is not None:
+            # Skip binary mode
+            assert not _is_binary_mode(mode_node)
+            # Skip non-literal mode (conservative — don't guess)
+            assert not _mode_is_unknown_non_literal(mode_node)
+
+        # Build the new keyword: encoding="utf-8"
+        encoding_kw = ast.keyword(arg="encoding", value=ast.Constant(value="utf-8"))
+
+        new_call = clone(node)
+        new_call.keywords = list(node.keywords) + [encoding_kw]
+        return Replace(node, new_call)

--- a/refactor/rules/py312_migration/override_decorator.py
+++ b/refactor/rules/py312_migration/override_decorator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.common import clone
+from refactor.core import Rule
+
+
+def _top_level_class_methods(tree: ast.AST, class_name: str) -> frozenset[str]:
+    """Return the set of method names defined in the top-level ClassDef named *class_name*."""
+    if not isinstance(tree, ast.Module):
+        return frozenset()
+    for stmt in tree.body:
+        if isinstance(stmt, ast.ClassDef) and stmt.name == class_name:
+            return frozenset(
+                node.name
+                for node in stmt.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+    return frozenset()
+
+
+def _has_override_decorator(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return True if the function already has @override or @typing.override."""
+    for dec in func.decorator_list:
+        if isinstance(dec, ast.Name) and dec.id == "override":
+            return True
+        if (
+            isinstance(dec, ast.Attribute)
+            and dec.attr == "override"
+            and isinstance(dec.value, ast.Name)
+            and dec.value.id == "typing"
+        ):
+            return True
+    return False
+
+
+class OverrideDecoratorRule(Rule):
+    """Add @typing.override to methods that override a same-module base class method.
+
+    Conservative: only transforms when the base class is defined as a top-level
+    ClassDef in the same module and has a method with the identical name.
+    Does NOT add an import for typing — the developer must ensure ``import typing``
+    (or ``from typing import override``) is already present.
+
+    Enable via ``--enable=override-decorator``.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+
+        # Must not already be decorated with @override / @typing.override
+        assert not _has_override_decorator(node)
+
+        # Find the enclosing ClassDef via ancestry
+        enclosing_class: ast.ClassDef | None = None
+        for parent in self.context.ancestry.get_parents(node):
+            if isinstance(parent, ast.ClassDef):
+                enclosing_class = parent
+                break
+
+        assert enclosing_class is not None
+
+        # The enclosing class must have at least one Name base
+        base_names = [base.id for base in enclosing_class.bases if isinstance(base, ast.Name)]
+        assert len(base_names) > 0
+
+        # At least one Name base must be a top-level ClassDef in this module with
+        # a method of the same name
+        method_name = node.name
+        found_in_base = any(
+            method_name in _top_level_class_methods(self.context.tree, base_name)
+            for base_name in base_names
+        )
+        assert found_in_base
+
+        # Build new decorator: typing.override
+        new_dec = ast.Attribute(
+            value=ast.Name(id="typing", ctx=ast.Load()),
+            attr="override",
+            ctx=ast.Load(),
+        )
+
+        new_func = clone(node)
+        new_func.decorator_list = [new_dec] + list(node.decorator_list)
+        return Replace(node, new_func)

--- a/refactor/rules/py312_migration/stdlib_additions.py
+++ b/refactor/rules/py312_migration/stdlib_additions.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import ast
+
+from refactor import Replace
+from refactor.common import clone
+from refactor.core import Rule
+
+
+class PairwiseRule(Rule):
+    """Replace ``zip(seq, seq[1:])`` with ``itertools.pairwise(seq)``.
+
+    ``itertools.pairwise`` was added in Python 3.10 and is the idiomatic way to
+    iterate over consecutive pairs from a sequence.
+
+    Conservative scope: only matches the simple NAME form, i.e. the first argument
+    is a bare ``Name`` node and the second argument is ``Name[1:]`` — the SAME
+    name in both positions.  More complex expressions (e.g. function calls or
+    attribute access as the iterable) are not matched to avoid false positives.
+
+    Opt-in only (``--enable=itertools-modern``).
+
+    NOTE: The rule does NOT add ``import itertools``.  The developer must ensure
+    that ``import itertools`` is present in the target file.
+
+    Matches:
+        zip(seq, seq[1:])           -> itertools.pairwise(seq)
+        zip(seq, seq[1:], strict=…) -> itertools.pairwise(seq)  (strict kwarg dropped)
+
+    Does NOT match:
+        zip(a, b)         — different names
+        zip(seq, seq[2:]) — wrong slice lower bound
+        zip(seq, seq[:-1], seq[1:]) — more than two args
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.Call)
+
+        # Must be a bare zip(…) call.
+        assert isinstance(node.func, ast.Name)
+        assert node.func.id == "zip"
+
+        # Exactly 2 positional arguments; only the optional strict= kwarg is allowed.
+        assert len(node.args) == 2
+        for kw in node.keywords:
+            assert kw.arg == "strict"
+
+        first, second = node.args
+
+        # First arg must be a plain Name.
+        assert isinstance(first, ast.Name)
+        seq_name = first.id
+
+        # Second arg must be Name[1:] with the SAME name.
+        assert isinstance(second, ast.Subscript)
+        assert isinstance(second.value, ast.Name)
+        assert second.value.id == seq_name
+
+        slc = second.slice
+        assert isinstance(slc, ast.Slice)
+        assert isinstance(slc.lower, ast.Constant)
+        assert slc.lower.value == 1
+        assert slc.upper is None
+        assert slc.step is None
+
+        # Build itertools.pairwise(seq).
+        new_node = ast.Call(
+            func=ast.Attribute(
+                value=ast.Name(id="itertools", ctx=ast.Load()),
+                attr="pairwise",
+                ctx=ast.Load(),
+            ),
+            args=[clone(first)],
+            keywords=[],
+        )
+        ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)
+
+
+class BatchedRule(Rule):
+    """Replace the canonical manual-chunking list comprehension with ``itertools.batched``.
+
+    ``itertools.batched`` was added in Python 3.12 and is the idiomatic way to
+    split an iterable into fixed-size chunks.
+
+    Conservative scope: only matches the exact canonical form::
+
+        [iterable[i:i+n] for i in range(0, len(iterable), n)]
+
+    where ``iterable``, ``i``, and ``n`` are all plain ``Name`` nodes, and the
+    same names are used consistently between the element expression and the
+    comprehension iterator.  Any deviation — different slice form, extra
+    generators, non-Name nodes — is left untouched.
+
+    Opt-in only (``--enable=itertools-modern``).
+
+    NOTE: The rule does NOT add ``import itertools``.  The developer must ensure
+    that ``import itertools`` is present in the target file.
+
+    Produces::
+
+        list(itertools.batched(iterable, n))
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        assert isinstance(node, ast.ListComp)
+
+        # Exactly one generator.
+        assert len(node.generators) == 1
+        gen = node.generators[0]
+
+        # Generator target must be a plain Name (the loop variable i).
+        assert isinstance(gen.target, ast.Name)
+        i_name = gen.target.id
+
+        # Generator iter must be range(0, len(iterable), n).
+        assert isinstance(gen.iter, ast.Call)
+        assert isinstance(gen.iter.func, ast.Name)
+        assert gen.iter.func.id == "range"
+        assert len(gen.iter.args) == 3
+        assert not gen.iter.keywords
+
+        range_start, range_stop, range_step = gen.iter.args
+
+        # range start must be Constant(0).
+        assert isinstance(range_start, ast.Constant)
+        assert range_start.value == 0
+
+        # range stop must be len(iterable) — len is a bare Name call.
+        assert isinstance(range_stop, ast.Call)
+        assert isinstance(range_stop.func, ast.Name)
+        assert range_stop.func.id == "len"
+        assert len(range_stop.args) == 1
+        assert not range_stop.keywords
+        assert isinstance(range_stop.args[0], ast.Name)
+        iterable_name = range_stop.args[0].id
+
+        # range step must be a plain Name (the chunk size n).
+        assert isinstance(range_step, ast.Name)
+        n_name = range_step.id
+
+        # No comprehension conditions (no `if` clauses).
+        assert not gen.ifs
+
+        # Element must be iterable[i:i+n].
+        elt = node.elt
+        assert isinstance(elt, ast.Subscript)
+        assert isinstance(elt.value, ast.Name)
+        assert elt.value.id == iterable_name
+
+        slc = elt.slice
+        assert isinstance(slc, ast.Slice)
+
+        # Slice lower must be the same loop variable i.
+        assert isinstance(slc.lower, ast.Name)
+        assert slc.lower.id == i_name
+
+        # Slice upper must be i + n (BinOp with Add).
+        assert isinstance(slc.upper, ast.BinOp)
+        assert isinstance(slc.upper.op, ast.Add)
+        assert isinstance(slc.upper.left, ast.Name)
+        assert slc.upper.left.id == i_name
+        assert isinstance(slc.upper.right, ast.Name)
+        assert slc.upper.right.id == n_name
+
+        assert slc.step is None
+
+        # Build list(itertools.batched(iterable, n)).
+        new_node = ast.Call(
+            func=ast.Name(id="list", ctx=ast.Load()),
+            args=[
+                ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id="itertools", ctx=ast.Load()),
+                        attr="batched",
+                        ctx=ast.Load(),
+                    ),
+                    args=[
+                        ast.Name(id=iterable_name, ctx=ast.Load()),
+                        ast.Name(id=n_name, ctx=ast.Load()),
+                    ],
+                    keywords=[],
+                )
+            ],
+            keywords=[],
+        )
+        ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)

--- a/refactor/rules/py312_migration/typing_modern.py
+++ b/refactor/rules/py312_migration/typing_modern.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import sys
 
 from refactor import Replace
 from refactor.common import clone
@@ -135,3 +136,183 @@ class TypingOptionalRule(Rule):
             right=ast.Constant(value=None),
         )
         return Replace(node, new_node)
+
+
+# ---------------------------------------------------------------------------
+# PEP 695 opt-in rules (--enable=pep695-types / --enable=pep695-generics)
+# These produce syntax that REQUIRES Python 3.12+.
+# ---------------------------------------------------------------------------
+
+
+class PEP695TypeAliasRule(Rule):
+    """Replace ``X: TypeAlias = Y`` (and ``X: typing.TypeAlias = Y``) with
+    the PEP 695 ``type X = Y`` statement.
+
+    Opt-in only: ``--enable=pep695-types``.
+    Requires Python 3.12+ at runtime (``ast.TypeAlias`` does not exist earlier).
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        # Guard: ast.TypeAlias doesn't exist on Python <3.12 — bail out.
+        if sys.version_info < (3, 12):
+            return None
+
+        assert isinstance(node, ast.AnnAssign)
+        assert node.value is not None
+        assert node.simple == 1
+
+        annotation = node.annotation
+        if isinstance(annotation, ast.Attribute):
+            # typing.TypeAlias
+            assert isinstance(annotation.value, ast.Name)
+            assert annotation.value.id == "typing"
+            assert annotation.attr == "TypeAlias"
+        elif isinstance(annotation, ast.Name):
+            assert annotation.id == "TypeAlias"
+        else:
+            return None
+
+        assert isinstance(node.target, ast.Name)
+        alias_name = node.target.id
+
+        new_node = ast.TypeAlias(  # type: ignore[attr-defined]  # 3.12+
+            name=ast.Name(id=alias_name, ctx=ast.Store()),
+            type_params=[],
+            value=node.value,
+        )
+        ast.fix_missing_locations(new_node)
+        return Replace(node, new_node)
+
+
+def _module_typevar_assignments(tree: ast.AST) -> dict[str, ast.Assign]:
+    """Return a mapping of name → Assign for simple ``T = TypeVar('T')``
+    declarations at module top level (no kwargs, no bounds)."""
+    result: dict[str, ast.Assign] = {}
+    if not isinstance(tree, ast.Module):
+        return result
+    for stmt in tree.body:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        if len(stmt.targets) != 1:
+            continue
+        target = stmt.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        is_typevar = (isinstance(func, ast.Name) and func.id == "TypeVar") or (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "typing"
+            and func.attr == "TypeVar"
+        )
+        if not is_typevar:
+            continue
+        # Must have exactly one positional arg (the name string), no kwargs.
+        if len(call.args) != 1 or call.keywords:
+            continue
+        result[target.id] = stmt
+    return result
+
+
+def _classes_using_typevar(tree: ast.AST, typevar_name: str) -> list[ast.ClassDef]:
+    """Return all ClassDef nodes at module level whose bases include
+    ``Generic[T]`` (bare or ``typing.Generic[T]``) for the given typevar."""
+    classes: list[ast.ClassDef] = []
+    if not isinstance(tree, ast.Module):
+        return classes
+    for stmt in tree.body:
+        if not isinstance(stmt, ast.ClassDef):
+            continue
+        for base in stmt.bases:
+            if _is_generic_subscript(base, typevar_name):
+                classes.append(stmt)
+                break
+    return classes
+
+
+def _is_generic_subscript(node: ast.expr, typevar_name: str) -> bool:
+    """Return True if *node* is ``Generic[T]`` or ``typing.Generic[T]``."""
+    if not isinstance(node, ast.Subscript):
+        return False
+    value = node.value
+    is_generic = (isinstance(value, ast.Name) and value.id == "Generic") or (
+        isinstance(value, ast.Attribute)
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "typing"
+        and value.attr == "Generic"
+    )
+    if not is_generic:
+        return False
+    slc = node.slice
+    return isinstance(slc, ast.Name) and slc.id == typevar_name
+
+
+class PEP695GenericClassRule(Rule):
+    """Transform ``class Foo(Generic[T]):`` to ``class Foo[T]:`` using PEP 695
+    type-parameter syntax.
+
+    Conservative scope — only fires when ALL of:
+
+    * ``T = TypeVar('T')`` exists at module top-level with no kwargs.
+    * ``T`` appears in Generic bases of EXACTLY one class.
+    * The class has ``Generic[T]`` as a base (bare or ``typing.Generic[T]``).
+
+    Opt-in only: ``--enable=pep695-generics``.
+    Requires Python 3.12+ at runtime (``ast.TypeVar`` node doesn't exist earlier).
+
+    NOTE: The original ``T = TypeVar('T')`` assignment is left in place (orphaned).
+    Removing it is deferred to a Phase 4 cleanup pass.
+    """
+
+    def match(self, node: ast.AST) -> Replace | None:
+        # Guard: ast.TypeVar (AST node) doesn't exist on Python <3.12.
+        if sys.version_info < (3, 12):
+            return None
+
+        assert isinstance(node, ast.ClassDef)
+
+        # Find which typevar name is used in Generic[T] bases.
+        typevar_name: str | None = None
+        for base in node.bases:
+            if not isinstance(base, ast.Subscript):
+                continue
+            slc = base.slice
+            if not isinstance(slc, ast.Name):
+                continue
+            value = base.value
+            is_generic = (isinstance(value, ast.Name) and value.id == "Generic") or (
+                isinstance(value, ast.Attribute)
+                and isinstance(value.value, ast.Name)
+                and value.value.id == "typing"
+                and value.attr == "Generic"
+            )
+            if is_generic:
+                typevar_name = slc.id
+                break
+
+        assert typevar_name is not None
+
+        tree = self.context.tree
+
+        # Verify T = TypeVar('T') exists at module level with no kwargs.
+        module_tvars = _module_typevar_assignments(tree)
+        assert typevar_name in module_tvars
+
+        # Verify T is used in EXACTLY one class at module level.
+        classes_using = _classes_using_typevar(tree, typevar_name)
+        assert len(classes_using) == 1
+
+        # Build new bases without Generic[T].
+        new_bases = [b for b in node.bases if not _is_generic_subscript(b, typevar_name)]
+
+        # Build PEP 695 TypeVar node.
+        tp_node = ast.TypeVar(name=typevar_name, bound=None)  # type: ignore[attr-defined]  # 3.12+
+
+        new_class = clone(node)
+        new_class.type_params = [tp_node]  # type: ignore[attr-defined]
+        new_class.bases = new_bases
+        ast.fix_missing_locations(new_class)
+        return Replace(node, new_class)

--- a/tests/test_py312_asyncio.py
+++ b/tests/test_py312_asyncio.py
@@ -1,4 +1,4 @@
-"""Tests for AsyncioGetEventLoopRule (Phase 1) and AsyncioEnsureFutureRule (Phase 2)."""
+"""Tests for AsyncioGetEventLoopRule (Phase 1), AsyncioEnsureFutureRule (Phase 2), and AsyncioWaitForToTimeoutRule (Phase 3)."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from refactor import Session
 from refactor.rules.py312_migration.asyncio_modern import (
     AsyncioEnsureFutureRule,
     AsyncioGetEventLoopRule,
+    AsyncioWaitForToTimeoutRule,
 )
 
 
@@ -186,3 +187,81 @@ class TestAsyncioEnsureFutureRule:
         """
         result = _run(AsyncioGetEventLoopRule, AsyncioEnsureFutureRule, source=source)
         assert result == textwrap.dedent(expected)
+
+
+class TestAsyncioWaitForToTimeoutRule:
+    """Test AsyncioWaitForToTimeoutRule transformations (Phase 3, opt-in)."""
+
+    def test_kwarg_timeout_form(self):
+        """Test: await asyncio.wait_for(coro, timeout=T) -> async with asyncio.timeout(T): await coro."""
+        source = """\
+            import asyncio
+
+            async def foo():
+                await asyncio.wait_for(coro, timeout=5)
+        """
+        expected = """\
+            import asyncio
+
+            async def foo():
+                async with asyncio.timeout(5):
+                    await coro
+        """
+        result = _run(AsyncioWaitForToTimeoutRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_positional_timeout_form(self):
+        """Test: await asyncio.wait_for(coro, T) -> async with asyncio.timeout(T): await coro."""
+        source = """\
+            import asyncio
+
+            async def foo():
+                await asyncio.wait_for(coro, 5)
+        """
+        expected = """\
+            import asyncio
+
+            async def foo():
+                async with asyncio.timeout(5):
+                    await coro
+        """
+        result = _run(AsyncioWaitForToTimeoutRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_assigned_await_no_transform(self):
+        """Test: result = await asyncio.wait_for(coro, timeout=5) should NOT be transformed.
+
+        The await is inside an ast.Assign, not an ast.Expr statement, so the
+        rule does not match and the source is returned unchanged.
+        """
+        source = """\
+            import asyncio
+
+            async def foo():
+                result = await asyncio.wait_for(coro, timeout=5)
+        """
+        result = _run(AsyncioWaitForToTimeoutRule, source=source)
+        assert result == textwrap.dedent(source)
+
+    def test_inside_sync_def_no_transform(self):
+        """Test: wait_for in sync def (no await statement) should NOT be transformed."""
+        source = """\
+            import asyncio
+
+            def foo():
+                result = asyncio.run(asyncio.wait_for(coro, timeout=5))
+        """
+        result = _run(AsyncioWaitForToTimeoutRule, source=source)
+        assert result == textwrap.dedent(source)
+
+    def test_idempotency(self):
+        """Test: already-transformed code (async with asyncio.timeout) is not re-fired."""
+        source = """\
+            import asyncio
+
+            async def foo():
+                async with asyncio.timeout(5):
+                    await coro
+        """
+        result = _run(AsyncioWaitForToTimeoutRule, source=source)
+        assert result == textwrap.dedent(source)

--- a/tests/test_py312_open_encoding.py
+++ b/tests/test_py312_open_encoding.py
@@ -1,0 +1,56 @@
+"""Tests for OpenEncodingRule."""
+
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.py312_migration.open_encoding import OpenEncodingRule
+
+
+def _run(*rules, source: str) -> str:
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+def test_open_no_mode_gets_encoding():
+    source = """\
+        f = open('file.txt')
+        """
+    expected = """\
+        f = open('file.txt', encoding='utf-8')
+        """
+    assert _run(OpenEncodingRule, source=source) == textwrap.dedent(expected)
+
+
+def test_open_text_mode_gets_encoding():
+    source = """\
+        f = open('file.txt', 'r')
+        """
+    expected = """\
+        f = open('file.txt', 'r', encoding='utf-8')
+        """
+    assert _run(OpenEncodingRule, source=source) == textwrap.dedent(expected)
+
+
+def test_noop_binary_mode_positional():
+    source = """\
+        f = open('file.txt', 'rb')
+        """
+    result = _run(OpenEncodingRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_noop_binary_mode_keyword():
+    source = """\
+        f = open('file.txt', mode='wb')
+        """
+    result = _run(OpenEncodingRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_noop_already_has_encoding():
+    source = """\
+        f = open('file.txt', encoding='latin-1')
+        """
+    result = _run(OpenEncodingRule, source=source)
+    assert result == textwrap.dedent(source)

--- a/tests/test_py312_override.py
+++ b/tests/test_py312_override.py
@@ -1,0 +1,112 @@
+"""Tests for OverrideDecoratorRule."""
+
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.py312_migration.override_decorator import OverrideDecoratorRule
+
+
+def _run(*rules, source: str) -> str:
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+def test_override_added_to_clearly_overriding_method():
+    source = """\
+        class Base:
+            def foo(self):
+                pass
+
+        class Child(Base):
+            def foo(self):
+                pass
+        """
+    expected = """\
+        class Base:
+            def foo(self):
+                pass
+
+        class Child(Base):
+            @typing.override
+            def foo(self):
+                pass
+        """
+    assert _run(OverrideDecoratorRule, source=source) == textwrap.dedent(expected)
+
+
+def test_noop_new_method_not_in_parent():
+    source = """\
+        class Base:
+            def foo(self):
+                pass
+
+        class Child(Base):
+            def bar(self):
+                pass
+        """
+    result = _run(OverrideDecoratorRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_noop_parent_not_in_same_module():
+    source = """\
+        class Child(ExternalBase):
+            def foo(self):
+                pass
+        """
+    result = _run(OverrideDecoratorRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_noop_already_has_typing_override():
+    source = """\
+        class Base:
+            def foo(self):
+                pass
+
+        class Child(Base):
+            @typing.override
+            def foo(self):
+                pass
+        """
+    result = _run(OverrideDecoratorRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_noop_already_has_bare_override():
+    source = """\
+        class Base:
+            def foo(self):
+                pass
+
+        class Child(Base):
+            @override
+            def foo(self):
+                pass
+        """
+    result = _run(OverrideDecoratorRule, source=source)
+    assert result == textwrap.dedent(source)
+
+
+def test_async_method_override_added():
+    source = """\
+        class Base:
+            async def fetch(self):
+                pass
+
+        class Child(Base):
+            async def fetch(self):
+                pass
+        """
+    expected = """\
+        class Base:
+            async def fetch(self):
+                pass
+
+        class Child(Base):
+            @typing.override
+            async def fetch(self):
+                pass
+        """
+    assert _run(OverrideDecoratorRule, source=source) == textwrap.dedent(expected)

--- a/tests/test_py312_stdlib_additions.py
+++ b/tests/test_py312_stdlib_additions.py
@@ -1,0 +1,106 @@
+"""Tests for PairwiseRule and BatchedRule (Phase 3, opt-in via --enable=itertools-modern)."""
+
+from __future__ import annotations
+
+import textwrap
+
+from refactor import Session
+from refactor.rules.py312_migration.stdlib_additions import BatchedRule, PairwiseRule
+
+
+def _run(*rules, source: str) -> str:
+    """Run refactor rules on source code."""
+    return Session(list(rules)).run(textwrap.dedent(source))
+
+
+class TestPairwiseRule:
+    """Test PairwiseRule: zip(seq, seq[1:]) -> itertools.pairwise(seq)."""
+
+    def test_simple_seq_name(self):
+        """zip(seq, seq[1:]) with name 'seq' is replaced."""
+        source = """\
+            import itertools
+
+            result = zip(seq, seq[1:])
+        """
+        expected = """\
+            import itertools
+
+            result = itertools.pairwise(seq)
+        """
+        result = _run(PairwiseRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_different_variable_name(self):
+        """zip(items, items[1:]) with name 'items' is replaced."""
+        source = """\
+            import itertools
+
+            for a, b in zip(items, items[1:]):
+                pass
+        """
+        expected = """\
+            import itertools
+
+            for a, b in itertools.pairwise(items):
+                pass
+        """
+        result = _run(PairwiseRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_noop_different_names(self):
+        """zip(a, b) with different names is not transformed."""
+        source = """\
+            import itertools
+
+            result = zip(a, b)
+        """
+        result = _run(PairwiseRule, source=source)
+        assert result == textwrap.dedent(source)
+
+    def test_noop_wrong_slice_lower(self):
+        """zip(seq, seq[2:]) with slice lower=2 is not transformed."""
+        source = """\
+            import itertools
+
+            result = zip(seq, seq[2:])
+        """
+        result = _run(PairwiseRule, source=source)
+        assert result == textwrap.dedent(source)
+
+
+class TestBatchedRule:
+    """Test BatchedRule: [items[i:i+n] for i in range(0, len(items), n)] -> list(itertools.batched(items, n))."""
+
+    def test_canonical_chunking_pattern(self):
+        """Exact canonical chunking list comprehension is replaced."""
+        source = """\
+            import itertools
+
+            chunks = [items[i:i+n] for i in range(0, len(items), n)]
+        """
+        expected = """\
+            import itertools
+
+            chunks = list(itertools.batched(items, n))
+        """
+        result = _run(BatchedRule, source=source)
+        assert result == textwrap.dedent(expected)
+
+    def test_noop_range_missing_start(self):
+        """[items[i:i+n] for i in range(len(items))] (2-arg range) is not transformed."""
+        source = """\
+            import itertools
+
+            chunks = [items[i:i+n] for i in range(len(items))]
+        """
+        result = _run(BatchedRule, source=source)
+        assert result == textwrap.dedent(source)
+
+    def test_noop_plain_list_comp(self):
+        """An unrelated list comprehension is not transformed."""
+        source = """\
+            result = [x * 2 for x in range(10)]
+        """
+        result = _run(BatchedRule, source=source)
+        assert result == textwrap.dedent(source)

--- a/tests/test_py312_typing.py
+++ b/tests/test_py312_typing.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import sys
 import textwrap
+
+import pytest
 
 from refactor import Session
 from refactor.rules.py312_migration.typing_modern import (
+    PEP695GenericClassRule,
+    PEP695TypeAliasRule,
     TypingDeprecatedAliasRule,
     TypingOptionalRule,
     TypingTypeRule,
 )
+
+PY312 = sys.version_info >= (3, 12)
 
 
 def _run(*rules, source: str) -> str:
@@ -210,3 +217,104 @@ def test_optional_existing_bitor_chains_none():
             pass
         """
     assert _run(TypingOptionalRule, source=source) == textwrap.dedent(expected)
+
+
+# ---------------------------------------------------------------------------
+# PEP695TypeAliasRule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not PY312, reason="PEP 695 syntax requires Python 3.12+")
+class TestPEP695TypeAliasRule:
+    def test_bare_typealias_to_pep695(self):
+        source = """\
+            Vec: TypeAlias = list[int]
+            """
+        expected = """\
+            type Vec = list[int]
+            """
+        assert _run(PEP695TypeAliasRule, source=source) == textwrap.dedent(expected)
+
+    def test_qualified_typealias_to_pep695(self):
+        source = """\
+            import typing
+
+            Vec: typing.TypeAlias = list[int]
+            """
+        expected = """\
+            import typing
+
+            type Vec = list[int]
+            """
+        assert _run(PEP695TypeAliasRule, source=source) == textwrap.dedent(expected)
+
+    def test_regular_annassign_no_transform(self):
+        """x: int = 5 is a plain AnnAssign, not a TypeAlias — must not fire."""
+        source = """\
+            x: int = 5
+            """
+        assert _run(PEP695TypeAliasRule, source=source) == textwrap.dedent(source)
+
+    def test_plain_assign_no_transform(self):
+        """Vec = list[int] has no annotation — rule must not fire."""
+        source = """\
+            Vec = list[int]
+            """
+        assert _run(PEP695TypeAliasRule, source=source) == textwrap.dedent(source)
+
+
+# ---------------------------------------------------------------------------
+# PEP695GenericClassRule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not PY312, reason="PEP 695 syntax requires Python 3.12+")
+class TestPEP695GenericClassRule:
+    def test_single_class_single_typevar(self):
+        """Simple Generic[T] class is transformed to class Foo[T]:."""
+        source = """\
+            from typing import Generic, TypeVar
+
+            T = TypeVar('T')
+
+            class Container(Generic[T]):
+                def __init__(self, value: T):
+                    self.value = value
+            """
+        expected = """\
+            from typing import Generic, TypeVar
+
+            T = TypeVar('T')
+
+            class Container[T]:
+                def __init__(self, value: T):
+                    self.value = value
+            """
+        assert _run(PEP695GenericClassRule, source=source) == textwrap.dedent(expected)
+
+    def test_typevar_with_bound_no_transform(self):
+        """T = TypeVar('T', bound=int) has a bound — rule must not fire."""
+        source = """\
+            from typing import Generic, TypeVar
+
+            T = TypeVar('T', bound=int)
+
+            class Container(Generic[T]):
+                pass
+            """
+        assert _run(PEP695GenericClassRule, source=source) == textwrap.dedent(source)
+
+    def test_typevar_used_in_two_classes_no_transform(self):
+        """T used in two classes — conservative scope, rule must not fire."""
+        source = """\
+            from typing import Generic, TypeVar
+
+            T = TypeVar('T')
+
+            class Box(Generic[T]):
+                pass
+
+            class Wrapper(Generic[T]):
+                pass
+            """
+        assert _run(PEP695GenericClassRule, source=source) == textwrap.dedent(source)


### PR DESCRIPTION
## Summary

Final PR in the comprehensive py312 rule pack series. Phase 3 delivers **opt-in / high-risk semantic transforms** gated behind `--enable=<group>` flags. The Hummingbot cron rebuild will NOT auto-apply these — they only run when explicitly enabled.

Follows PR #32 (Phase 1) and PR #33 (Phase 2), both merged.

## What's in this PR

### 1. CLI bugfix (commit `1ce583b`)

Fixes a TypeError in `cli_py312.py` that was masked while `OPTIN_RULE_GROUPS` was empty:
```python
# Before (TypeError when dict non-empty):
", ".join(sorted(OPTIN_RULE_GROUPS) | {"all"})
# After:
", ".join(sorted(set(OPTIN_RULE_GROUPS) | {"all"}))
```
The bug existed in PR #32 but was unreachable until Phase 3 populated the dict.

### 2. Rule pack (commit `e19c352`)

7 rules across 5 modules:

| Module | New rule(s) | What |
|---|---|---|
| `asyncio_modern` (extended) | `AsyncioWaitForToTimeoutRule` | `await asyncio.wait_for(coro, timeout=T)` → `async with asyncio.timeout(T): await coro` |
| `typing_modern` (extended) | `PEP695TypeAliasRule` | `X: TypeAlias = Y` → `type X = Y` |
| `typing_modern` (extended) | `PEP695GenericClassRule` | `class Foo(Generic[T]):` → `class Foo[T]:` (single unbounded TypeVar) |
| `override_decorator` (new) | `OverrideDecoratorRule` | Adds `@typing.override` to clearly-overriding methods (same-module parent) |
| `open_encoding` (new) | `OpenEncodingRule` | Adds `encoding="utf-8"` to text-mode `open()` calls |
| `stdlib_additions` (new) | `PairwiseRule` | `zip(seq, seq[1:])` → `itertools.pairwise(seq)` |
| `stdlib_additions` (new) | `BatchedRule` | `[seq[i:i+n] for i in range(0, len(seq), n)]` → `list(itertools.batched(seq, n))` |

**~30 new tests** (53 total in the 5 affected test files). PEP 695 tests gated with `@pytest.mark.skipif(not PY312, ...)` since the output syntax is a parse error on Python <3.12.

### 3. OPTIN_RULE_GROUPS wiring (commit `b71708c`)

`__init__.py`'s previously-empty `OPTIN_RULE_GROUPS` dict now has 6 keys:

| Group | Rules |
|---|---|
| `asyncio-timeout` | `AsyncioWaitForToTimeoutRule` |
| `pep695-types` | `PEP695TypeAliasRule` |
| `pep695-generics` | `PEP695GenericClassRule` |
| `override-decorator` | `OverrideDecoratorRule` |
| `encoding-warning` | `OpenEncodingRule` |
| `itertools-modern` | `PairwiseRule`, `BatchedRule` |

## Usage

```bash
# Default (Phase 1+2 only, safe):
refactor-py312 src/

# Add one opt-in group:
refactor-py312 --enable=override-decorator src/

# Compose multiple groups:
refactor-py312 --enable=pep695-types --enable=encoding-warning src/

# All opt-in groups (full 27 rules):
refactor-py312 --enable=all src/
```

## Conservative scope decisions

Opt-in rules tolerate false-negatives but must avoid false-positives. To stay safe:

- **PEP695GenericClassRule**: only fires when the TypeVar has no bounds/constraints/default and is used in exactly one class. Skips `T = TypeVar('T', bound=int)`. Leaves the orphan `T = TypeVar('T')` line behind (Phase 4 cleanup concern, documented).
- **OverrideDecoratorRule**: only fires when the parent class is defined in the same module. External base classes are out of scope (would require import resolution).
- **OpenEncodingRule**: only fires for `open()` (bare name). Skips `builtins.open`, binary mode (`'rb'`, `mode='wb'`), and non-literal mode expressions.
- **PairwiseRule**: only matches the exact `zip(NAME, NAME[1:])` form. Skips `zip(a[:-1], a[1:])` and other variants.
- **BatchedRule**: only matches the exact `[seq[i:i+n] for i in range(0, len(seq), n)]` list-comprehension form. Other chunking idioms (functools.reduce, while-loops) untouched.
- **AsyncioWaitForToTimeoutRule**: only matches `await asyncio.wait_for(...)` as a bare expression statement. Skips assignments and expressions used in larger contexts (cancellation semantics differ — must be deliberate).

## Known limitations (documented in rule docstrings)

- `OverrideDecoratorRule` does not add `import typing` (developer responsibility)
- `PairwiseRule` and `BatchedRule` do not add `import itertools`
- `PEP695GenericClassRule` leaves the now-orphaned `T = TypeVar('T')` line in place
- `StrEnumRule`/`IntEnumRule` (Phase 2) do not auto-update enum imports (pre-existing limitation)

All of these are acceptable for opt-in rules — the developer is running deliberately and can clean up.

## Test plan

- [x] `pixi run lint-fix && pixi run lint` clean
- [x] `pixi run format` clean
- [x] `pixi run -- pytest tests/test_py312_*.py -v` → 53/53 in Phase 3 test files
- [x] `pixi run -- refactor-py312 --help` lists all 6 opt-in groups + `all`
- [ ] Full CI gate (this PR triggers)
- [ ] Manual smoke with --enable=all against Hummingbot tree (reviewer post-merge)

Plan: `~/.claude/plans/py312-rule-pack-comprehensive.md` (Phase 3 section)