### PR TITLE
fix(py312): add __future__ annotations import when emitting X | None

### DIFF
--- a/refactor/rules/py312_migration/__init__.py
+++ b/refactor/rules/py312_migration/__init__.py
@@ -42,6 +42,7 @@ from refactor.rules.py312_migration.override_decorator import OverrideDecoratorR
 from refactor.rules.py312_migration.stdlib_additions import BatchedRule, PairwiseRule
 from refactor.rules.py312_migration.stdlib_removed import RemovedStdlibImportRule
 from refactor.rules.py312_migration.typing_modern import (
+    EnsureFutureAnnotationsImportRule,
     PEP695GenericClassRule,
     PEP695TypeAliasRule,
     TypingDeprecatedAliasRule,
@@ -82,6 +83,7 @@ IDIOMATIC_RULES = [
     TypingDeprecatedAliasRule,
     TypingTypeRule,
     TypingOptionalRule,
+    EnsureFutureAnnotationsImportRule,
 ]
 
 OPTIN_RULE_GROUPS = {
@@ -107,6 +109,7 @@ __all__ = [
     "DistutilsSysconfigRule",
     "DistutilsUtilStrtoboolRule",
     "DistutilsVersionRule",
+    "EnsureFutureAnnotationsImportRule",
     "InspectFormatargspecRule",
     "InspectGetargspecRule",
     "IntEnumRule",

--- a/refactor/rules/py312_migration/typing_modern.py
+++ b/refactor/rules/py312_migration/typing_modern.py
@@ -4,6 +4,7 @@ import ast
 import sys
 
 from refactor import Replace
+from refactor.actions import InsertBefore
 from refactor.common import clone
 from refactor.core import Rule
 
@@ -316,3 +317,86 @@ class PEP695GenericClassRule(Rule):
         new_class.bases = new_bases
         ast.fix_missing_locations(new_class)
         return Replace(node, new_class)
+
+
+def _has_future_annotations(tree: ast.AST) -> bool:
+    """Return True if the module already imports `annotations` from `__future__`."""
+    if not isinstance(tree, ast.Module):
+        return False
+    for stmt in tree.body:
+        if isinstance(stmt, ast.ImportFrom) and stmt.module == "__future__":
+            if any(alias.name == "annotations" for alias in stmt.names):
+                return True
+    return False
+
+
+def _iter_annotations(tree: ast.Module):
+    """Yield every annotation expression node in the module."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.arg) and node.annotation is not None:
+            yield node.annotation
+        elif (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.returns is not None
+        ):
+            yield node.returns
+        elif isinstance(node, ast.AnnAssign):
+            yield node.annotation
+
+
+def _contains_pep604_union(annotation: ast.AST) -> bool:
+    """Return True if an annotation subtree contains a PEP 604 (X | Y) union."""
+    return any(
+        isinstance(sub, ast.BinOp) and isinstance(sub.op, ast.BitOr)
+        for sub in ast.walk(annotation)
+    )
+
+
+def _module_uses_pep604_union(tree: ast.Module) -> bool:
+    return any(_contains_pep604_union(ann) for ann in _iter_annotations(tree))
+
+
+def _future_anchor_index(body: list[ast.stmt]) -> int:
+    """Index of the statement the future import must precede (after a docstring)."""
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        return 1
+    return 0
+
+
+class EnsureFutureAnnotationsImportRule(Rule):
+    """Insert ``from __future__ import annotations`` when modernized annotations
+    use PEP 604 unions (``X | None``) but the module lacks the future import.
+
+    TypingOptionalRule rewrites ``Optional[X]`` to ``X | None``. Without the
+    future import, that annotation is evaluated eagerly at definition time, which
+    raises ``TypeError`` for forward references (``Optional["Foo"]`` becomes
+    ``"Foo" | None``). Importing ``annotations`` makes annotations lazy strings,
+    fixing the whole class of runtime breakage from emitted unions.
+    """
+
+    def match(self, node: ast.AST) -> InsertBefore | None:
+        assert isinstance(node, ast.stmt)
+
+        tree = self.context.tree
+        assert isinstance(tree, ast.Module)
+
+        body = tree.body
+        anchor_index = _future_anchor_index(body)
+        assert anchor_index < len(body)
+        # Fire once, anchored on the statement that should follow the import.
+        assert node is body[anchor_index]
+
+        assert not _has_future_annotations(tree)
+        assert _module_uses_pep604_union(tree)
+
+        future_import = ast.ImportFrom(
+            module="__future__",
+            names=[ast.alias(name="annotations")],
+            level=0,
+        )
+        return InsertBefore(node, target=future_import)

--- a/tests/test_py312_typing.py
+++ b/tests/test_py312_typing.py
@@ -9,6 +9,7 @@ import pytest
 
 from refactor import Session
 from refactor.rules.py312_migration.typing_modern import (
+    EnsureFutureAnnotationsImportRule,
     PEP695GenericClassRule,
     PEP695TypeAliasRule,
     TypingDeprecatedAliasRule,
@@ -318,3 +319,79 @@ class TestPEP695GenericClassRule:
                 pass
             """
         assert _run(PEP695GenericClassRule, source=source) == textwrap.dedent(source)
+
+
+# ---------------------------------------------------------------------------
+# EnsureFutureAnnotationsImportRule
+# ---------------------------------------------------------------------------
+
+
+def test_optional_emission_adds_future_import():
+    source = """\
+        from typing import Optional
+
+        def foo(x: Optional[int]) -> None:
+            pass
+        """
+    result = _run(TypingOptionalRule, EnsureFutureAnnotationsImportRule, source=source)
+    assert "int | None" in result
+    assert result.count("from __future__ import annotations") == 1
+
+
+def test_forward_ref_union_adds_future_import():
+    source = """\
+        from typing import Optional
+
+        def foo(x: Optional["Foo"]) -> None:
+            pass
+        """
+    result = _run(TypingOptionalRule, EnsureFutureAnnotationsImportRule, source=source)
+    assert result.count("from __future__ import annotations") == 1
+
+
+def test_future_import_not_duplicated_when_present():
+    source = """\
+        from __future__ import annotations
+
+        from typing import Optional
+
+        def foo(x: Optional[int]) -> None:
+            pass
+        """
+    result = _run(TypingOptionalRule, EnsureFutureAnnotationsImportRule, source=source)
+    assert "int | None" in result
+    assert result.count("from __future__ import annotations") == 1
+
+
+def test_future_import_inserted_after_docstring():
+    source = '''\
+        """Module docstring."""
+
+        from typing import Optional
+
+        def foo(x: Optional[int]) -> None:
+            pass
+        '''
+    result = _run(TypingOptionalRule, EnsureFutureAnnotationsImportRule, source=source)
+    assert result.count("from __future__ import annotations") == 1
+    assert result.index('"""Module docstring."""') < result.index(
+        "from __future__ import annotations"
+    )
+
+
+def test_no_future_import_when_no_union():
+    source = """\
+        def foo(x: int) -> None:
+            pass
+        """
+    result = _run(EnsureFutureAnnotationsImportRule, source=source)
+    assert "from __future__ import annotations" not in result
+
+
+def test_no_future_import_for_runtime_bitor():
+    source = """\
+        def foo(a, b):
+            return a | b
+        """
+    result = _run(EnsureFutureAnnotationsImportRule, source=source)
+    assert "from __future__ import annotations" not in result


### PR DESCRIPTION
## Problem

`TypingOptionalRule` rewrites `Optional[X]` -> `X | None` but never adds `from __future__ import annotations`. Without that import, annotations are evaluated eagerly at definition time, so a forward reference like `Optional["Foo"]` becomes `"Foo" | None` and raises `TypeError: unsupported operand type(s) for |: 'str' and 'NoneType'` at import time.

This bit the Hummingbot `ci-base` rebuild for real (e.g. `inventory_cost.py` emitted `"InventoryCost" | None`, raising at import and blocking pytest collection of ~30 modules), and the same latent breakage exists across ~526 ci-base files that already carry `X | None` annotations from earlier transform runs.

## Fix

New `EnsureFutureAnnotationsImportRule` (wired into `IDIOMATIC_RULES`, so it runs by default): when a module's annotations use a PEP 604 union (`X | Y`) and the module lacks `from __future__ import annotations`, it inserts the future import exactly once, after any module docstring. Making annotations lazy (string) defers evaluation and fixes the whole class of runtime breakage from emitted unions.

Properties:
- Idempotent — does not duplicate the import when already present.
- Scoped to annotation context — does not fire on runtime bitwise-or (`a | b`).
- Docstring-aware placement.

## Tests

6 new tests in `tests/test_py312_typing.py`: emission adds the import, forward-ref union, no duplication when present, insertion after docstring, no-op when no union, and no false-trigger on a runtime `|` expression. Full suite green.

Generated with Claude Code.